### PR TITLE
Add server integration test suite and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project overview
+
+A Star Wars TIE Fighter browser game: a Three.js (WebGL) client with single-player campaign missions and a Socket.IO-based multiplayer mode, backed by a small Node/Express real-time server. There are two independent npm packages in this repo (`server/` and `webGL/`), tied together only by the root `package.json` orchestration scripts — they do not share `node_modules` or build tooling.
+
+`ClientExamples/` (Android + plain-Node socket clients) is reference/prototype code, not part of the main build.
+
+## Commands
+
+Install dependencies for both sub-projects from the repo root:
+```
+npm run build
+```
+(equivalent to `cd server && npm i && cd ../webGL && npm i`; `install.bat` does the same on Windows.)
+
+Before first run, create `server/src/.env` (gitignored, not committed) containing:
+```
+WEB_SERVER=3000
+```
+
+Run the server (must be launched from `server/src` — see Gotchas below):
+```
+cd server/src
+node main
+```
+The Express server serves the compiled-free `webGL/` directory as static content and listens on `WEB_SERVER` from `.env`; open `http://localhost:<WEB_SERVER>/` in a browser to play.
+
+Run the integration test suite (spawns the real server on a scratch port and hits it over HTTP/Socket.IO like a browser would):
+```
+npm test
+```
+(delegates to `cd server && npm test`, i.e. `node --test`, using Node's built-in test runner — no test framework dependency). The single test file is `server/test/integration.test.js`. To run it directly: `cd server && node --test test/integration.test.js`.
+
+There is no linter configured anywhere in the repo.
+
+## Architecture
+
+### Server (`server/src/`)
+
+- `main.js` — entrypoint. Loads `.env`, then starts `WebpageServer`. A raw TCP-socket transport (`TCPServer.js`) exists but is entirely commented out in `main.js` — it's legacy/dead code kept for reference; Socket.IO is the real transport.
+- `WebpageServer.js` — Express + `http` + `socket.io` server. Serves `webGL/index.html` and static assets, and owns all realtime multiplayer state in an in-memory `gameState` object keyed by room name (no persistence — state is lost on restart). Handles room join/leave, ship-selection sync, game start, and per-tick position/state broadcast (`GAME_STATE`) to other players in the same room, plus disconnect cleanup.
+- `events.js` — string-constant map of the socket event names the server understands. This is a separate, smaller file from the client's `webGL/js/eventBus/events.js` (which also has local-only UI events) — they are not shared/imported between server and client, just kept manually in sync by convention.
+
+### Client (`webGL/`)
+
+No bundler or build step: the browser loads plain ES modules directly (`<script type="module" src="./js/main.js">` in `index.html`). Three.js and `GLTFLoader` are imported by an absolute CDN URL (`https://threejsfundamentals.org/threejs/resources/threejs/r119/...`) at the top of nearly every file that touches THREE, rather than from `node_modules` — bumping the three.js version means updating this URL consistently across all of those files.
+
+- `js/main.js` — bootstraps the app: wires DOM menu navigation (main menu → ship-select/campaign submenu → mission briefing → gameplay), keyboard/resize listeners, and drives the render loop via `requestAnimationFrame`, calling `sceneManager.update()` and `TWEEN.update()` each frame.
+- `js/SceneManager.js` — factory keyed by a "screen" string (`menu`, `shipselect`, `multiplayer`, or a campaign mission key such as `missionOne`). Tears down the previous scene and builds the next one by loading assets through `Manager` and delegating to the matching scene builder. Owns the shared per-frame update loop: syncs the skybox to the camera, updates the targeting reticle, drives weapon collision checks, and renders both the main view and the HUD "target computer" mini-view.
+- `js/scenes/{menu,campaign,multiplayer}/` — each scene module is a factory that builds a `THREE.Scene`, camera(s)/renderer(s), loads ships via `ModelLoader`, wires up `CollisionManager`/`WeaponsCollisionManager`, and returns `{ scene, camera, renderer, sceneSubjects, controls, weaponsCollision }` for `SceneManager` to consume.
+- `js/utils/Manager.js` + `js/utils/ModelLoader.js` — asset preloading. `Manager` drives the `#loading` progress bar and hands loaded models to the scene's callback. `ModelLoader` maps ship names (`TIE_FIGHTER`, `X_WING`, `ISD`, `SHUTTLE`, etc.) to `.glb` files under `webGL/models/`, and for NPC ships attaches a per-ship `FiniteStateMachine` (fighters: `form` → `attack` → `evade` → `returnToAttack`; the shuttle: `depart` → `return` → `slowDown` → `rise` → `docked` → `lower` → `turnToDepart`) that drives `controls/NpcControls.js`.
+- `js/campaignMenu/campaign.js` and `webGL/sceneConfig.js` hold per-mission ship rosters/weapons and global scene defaults (floor, skybox, audio, control scheme) respectively; both are normalized through `js/utils/SceneConfigUtils.js#parseConfiguration`.
+- `js/SocketIO.js` bridges the local `EventBus` (`js/eventBus/EventBus.js`, a minimal pub/sub) to Socket.IO events shared with the server: room join/leave, ship selection, `GAME_STATE` position sync, opponent-disconnect handling.
+- Player input is either `controls/PlayerControls.js` (basic) or `controls/FlyControls.js` (full flight model), selected via `sceneConfig.js`'s `controls.flightControls` flag; `controls/NpcControls.js` provides the equivalent movement primitives for FSM-driven AI ships.
+- Collision handling is split in two: `controls/CollisionManager.js` for ship-vs-static-geometry (e.g. the floor), and `controls/WeaponsCollisionManager.js` for laser hit detection — both post to `EventBus` for HUD/explosion code to react to.
+- `js/HUD/hud.js` + `js/HUD/targetingReticle.js` (in-flight shields/hull/target overlay) and `js/missionBriefing/missionBriefing.js` (pre-mission briefing screen) are DOM overlays driven by campaign config and `EventBus` events — they are not part of the THREE.js scene graph.
+
+## Gotchas
+
+- `WebpageServer.js` resolves its static-file path relative to `__dirname` (`../../../webGL`), so the server must be started from inside `server/src` (`node main`) — running it from another working directory breaks static asset serving.
+- Multiplayer game state is entirely in-memory on the server; restarting the server drops all active rooms/players.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ the web server will run on port 3000 unless changed in the .env file
 
 The webpage will be available at `http://localhost:8080/`
 
+### Testing
+
+Run the integration test suite from the root folder of the project
+
+```
+npm test
+```
+
+This spawns the real server on a scratch port and checks it over HTTP/Socket.IO the same way a browser would (index page, client JS, CSS, a ship model, and the Socket.IO handshake). It uses Node's built-in test runner, so no extra install is needed.
+
 ## Running on an EC2 instance ** for my EC2 its older and node 17.9.1 only works ** 
 I would have to re-create a new EC2 instance with newer distro
 - curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Creating a Tie Fighter game using [PierfrancescoSoffritti's Configurable Three JS App template](https://github.com/PierfrancescoSoffritti/configurable-threejs-app). Check it out  he has done an amazing job.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "cd server && npm test",
     "build": "cd server && npm i && cd .. && cd webGL && npm i",
     "start": "node server/src/main.js"
   },

--- a/server/package.json
+++ b/server/package.json
@@ -2,6 +2,9 @@
   "name": "server",
   "version": "0.0.1",
   "description": "server",
+  "scripts": {
+    "test": "node --test"
+  },
   "dependencies": {
     "dotenv": "^8.2.0",
     "express": "^4.16.3",

--- a/server/test/integration.test.js
+++ b/server/test/integration.test.js
@@ -1,0 +1,83 @@
+// Boots the real server as a child process against the real webGL
+// static assets and hits it over HTTP/Socket.IO, the same way a
+// browser would. Uses a non-default port so it doesn't collide with
+// a server already running locally.
+const { test, before, after } = require('node:test');
+const assert = require('node:assert');
+const { spawn } = require('node:child_process');
+const path = require('node:path');
+
+const PORT = process.env.TEST_WEB_SERVER_PORT || 3050;
+const BASE_URL = `http://localhost:${PORT}`;
+const SERVER_SRC_DIR = path.join(__dirname, '..', 'src');
+
+let serverProcess;
+
+before(async () => {
+    serverProcess = spawn(process.execPath, ['main.js'], {
+        cwd: SERVER_SRC_DIR,
+        env: { ...process.env, WEB_SERVER: String(PORT) },
+        stdio: 'pipe'
+    });
+
+    await waitForServer(15000);
+});
+
+after(() => {
+    if (serverProcess) serverProcess.kill();
+});
+
+async function waitForServer(timeoutMs) {
+    const start = Date.now();
+    let lastError;
+    while (Date.now() - start < timeoutMs) {
+        try {
+            const res = await fetch(BASE_URL + '/');
+            if (res.ok) return;
+        } catch (err) {
+            lastError = err;
+        }
+        await new Promise(resolve => setTimeout(resolve, 200));
+    }
+    throw new Error(`Server did not start within ${timeoutMs}ms: ${lastError}`);
+}
+
+test('serves the game index page', async () => {
+    const res = await fetch(BASE_URL + '/');
+    assert.strictEqual(res.status, 200);
+    const body = await res.text();
+    assert.match(body, /<title>WebGLScene<\/title>/);
+});
+
+test('serves the client bootstrap module', async () => {
+    const res = await fetch(BASE_URL + '/js/main.js');
+    assert.strictEqual(res.status, 200);
+});
+
+test('serves the global scene configuration', async () => {
+    const res = await fetch(BASE_URL + '/sceneConfig.js');
+    assert.strictEqual(res.status, 200);
+});
+
+test('serves stylesheets', async () => {
+    const res = await fetch(BASE_URL + '/css/style.css');
+    assert.strictEqual(res.status, 200);
+});
+
+test('serves a ship model', async () => {
+    const res = await fetch(BASE_URL + '/models/tie-fighter/tie.glb');
+    assert.strictEqual(res.status, 200);
+});
+
+test('serves the socket.io client library', async () => {
+    const res = await fetch(BASE_URL + '/socket.io/socket.io.js');
+    assert.strictEqual(res.status, 200);
+});
+
+test('completes a socket.io engine handshake', async () => {
+    const res = await fetch(BASE_URL + '/socket.io/?EIO=3&transport=polling');
+    assert.strictEqual(res.status, 200);
+    const body = await res.text();
+    assert.match(body, /"sid":"[^"]+"/);
+    assert.match(body, /"upgrades":\["websocket"\]/);
+});

--- a/webGL/js/HUD/hud.js
+++ b/webGL/js/HUD/hud.js
@@ -76,9 +76,30 @@ export default class HUD {
 
     acquireNewTarget = (target) => {
         this.target = target;
+
+        // compute bounding box to get visual center and size
+        const box = new THREE.Box3().setFromObject(target);
+        const size = new THREE.Vector3();
+        box.getSize(size);
+        const center = new THREE.Vector3();
+        box.getCenter(center);
+
+        // position goal relative to the visual center
+        // distance scales with the largest dimension of the ship
+        const maxDim = Math.max(size.x, size.y, size.z);
+        const distance = maxDim * 0.8;
+
         this.goal = new THREE.Object3D();
-        target.add( this.goal );
-        this.goal.position.set(0, 5, 20);
+        target.add(this.goal);
+
+        // offset goal from the visual center in local space
+        const localCenter = center.clone().sub(target.position);
+        this.goal.position.set(
+            localCenter.x,
+            localCenter.y + size.y * 0.1,
+            localCenter.z + distance
+        );
+
         this.setCameraPositionRelativeToMeshAndFollow(this.camera, target);
     };
 
@@ -90,7 +111,14 @@ export default class HUD {
         const temp = new THREE.Vector3();
         temp.setFromMatrixPosition(this.goal.matrixWorld);
         camera.position.lerp(temp, .2);
-        camera.lookAt( mesh.position );
+
+        // use Box3 center for large models like the ISD
+        // so the camera looks at the visual center not the group pivot
+        const box = new THREE.Box3().setFromObject(mesh);
+        const center = new THREE.Vector3();
+        box.getCenter(center);
+
+        camera.lookAt(center);
     };
 
     update = () => {

--- a/webGL/js/HUD/targetingReticle.js
+++ b/webGL/js/HUD/targetingReticle.js
@@ -2,23 +2,19 @@ import * as THREE from 'https://threejsfundamentals.org/threejs/resources/threej
 
 const RETICLE_COLOR       = '#00ff44';
 const RETICLE_ALPHA       = 0.85;
-const BRACKET_SIZE        = 40;   // half-size of the corner brackets in px
+const BRACKET_SIZE        = 40;   // minimum half-size of the corner brackets in px
 const BRACKET_LEG         = 14;   // length of each bracket arm in px
 const ARROW_MARGIN        = 48;   // px from screen edge for off-screen arrow
 const ARROW_SIZE          = 14;   // px, half-width of arrowhead
 const LOCK_PULSE_SPEED    = 2.5;  // hz, flicker rate when locked
 
 export class TargetingReticle {
-    /**
-     * @param {HTMLCanvasElement} overlayCanvas  – a fullscreen 2D canvas on top of the WebGL canvas
-     * @param {THREE.Camera}      camera
-     */
     constructor(overlayCanvas, camera) {
         this.canvas  = overlayCanvas;
         this.ctx     = overlayCanvas.getContext('2d');
         this.camera  = camera;
-        this.target  = null;   // THREE.Object3D
-        this.locked  = false;  // true = pulsing lock box
+        this.target  = null;
+        this.locked  = false;
         this._clock  = 0;
     }
 
@@ -38,7 +34,6 @@ export class TargetingReticle {
         this.locked = locked;
     }
 
-    /** Call this every frame from your render loop, passing delta time in seconds */
     update(dt) {
         this._clearCanvas();
         if (!this.target || !this.camera) return;
@@ -46,9 +41,10 @@ export class TargetingReticle {
         this.camera.updateMatrixWorld();
         this._clock += dt;
 
-        // --- project target world position to NDC then screen ---
+        // use Box3 center for accurate position on large models like ISD
+        const box = new THREE.Box3().setFromObject(this.target);
         const worldPos = new THREE.Vector3();
-        this.target.getWorldPosition(worldPos);
+        box.getCenter(worldPos);
 
         const ndc = worldPos.clone().project(this.camera);
 
@@ -58,13 +54,25 @@ export class TargetingReticle {
         const sx = ( ndc.x * 0.5 + 0.5) * W;
         const sy = (-ndc.y * 0.5 + 0.5) * H;
 
+        // scale bracket size to match the target's projected screen size
+        const boxSize = new THREE.Vector3();
+        box.getSize(boxSize);
+        const maxDim = Math.max(boxSize.x, boxSize.y, boxSize.z);
+
+        // project a point at maxDim distance from center to estimate screen size
+        const edgePos  = worldPos.clone().add(new THREE.Vector3(maxDim * 0.5, 0, 0));
+        const edgeNdc  = edgePos.clone().project(this.camera);
+        const edgeSx   = (edgeNdc.x * 0.5 + 0.5) * W;
+        const centerSx = (ndc.x * 0.5 + 0.5) * W;
+        const dynamicBracket = Math.max(BRACKET_SIZE, Math.abs(edgeSx - centerSx));
+
         // ndc.z > 1 means behind the camera
         const behindCamera = ndc.z > 1;
         const onScreen = !behindCamera
-            && sx > BRACKET_SIZE
-            && sx < W - BRACKET_SIZE
-            && sy > BRACKET_SIZE
-            && sy < H - BRACKET_SIZE;
+            && sx > dynamicBracket
+            && sx < W - dynamicBracket
+            && sy > dynamicBracket
+            && sy < H - dynamicBracket;
 
         const ctx = this.ctx;
         ctx.save();
@@ -80,9 +88,9 @@ export class TargetingReticle {
         ctx.lineWidth   = 1.5;
 
         if (onScreen) {
-            this._drawBrackets(ctx, sx, sy, BRACKET_SIZE, BRACKET_LEG);
+            this._drawBrackets(ctx, sx, sy, dynamicBracket, BRACKET_LEG);
             if (this.locked) {
-                this._drawLockText(ctx, sx, sy, BRACKET_SIZE);
+                this._drawLockText(ctx, sx, sy, dynamicBracket);
             }
         } else {
             this._drawOffScreenArrow(ctx, worldPos, W, H, behindCamera);
@@ -91,13 +99,10 @@ export class TargetingReticle {
         ctx.restore();
     }
 
-    // ─── private ───────────────────────────────────────────────────────────────
-
     _clearCanvas() {
         this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
     }
 
-    /** Four-corner bracket box */
     _drawBrackets(ctx, cx, cy, half, leg) {
         const L = cx - half, R = cx + half;
         const T = cy - half, B = cy + half;
@@ -120,26 +125,18 @@ export class TargetingReticle {
         ctx.fillText('LOCKED', cx, cy + half + 14);
     }
 
-    /**
-     * Clamp the direction to the screen edge and draw an arrowhead there.
-     * When behind the camera we flip the direction so the arrow still
-     * points toward the target rather than away from it.
-     */
     _drawOffScreenArrow(ctx, worldPos, W, H, behindCamera) {
         const cx = W / 2, cy = H / 2;
 
-        // get screen-space direction from center to projected point
         const ndc = worldPos.clone().project(this.camera);
         let dx = ndc.x;
         let dy = -ndc.y;
 
         if (behindCamera) { dx = -dx; dy = -dy; }
 
-        // normalise
         const len = Math.sqrt(dx * dx + dy * dy) || 1;
         dx /= len; dy /= len;
 
-        // find intersection with screen rect (inset by ARROW_MARGIN)
         const margin = ARROW_MARGIN;
         const halfW  = cx - margin;
         const halfH  = cy - margin;
@@ -151,23 +148,21 @@ export class TargetingReticle {
         const ax = cx + dx * t;
         const ay = cy + dy * t;
 
-        // arrowhead
         const angle = Math.atan2(dy, dx);
         const s = ARROW_SIZE;
 
         ctx.beginPath();
-        ctx.moveTo(ax + Math.cos(angle)           * s,
-            ay + Math.sin(angle)           * s);
-        ctx.lineTo(ax + Math.cos(angle + 2.4)     * s * 0.7,
-            ay + Math.sin(angle + 2.4)     * s * 0.7);
-        ctx.lineTo(ax + Math.cos(angle - 2.4)     * s * 0.7,
-            ay + Math.sin(angle - 2.4)     * s * 0.7);
+        ctx.moveTo(ax + Math.cos(angle)       * s,
+            ay + Math.sin(angle)       * s);
+        ctx.lineTo(ax + Math.cos(angle + 2.4) * s * 0.7,
+            ay + Math.sin(angle + 2.4) * s * 0.7);
+        ctx.lineTo(ax + Math.cos(angle - 2.4) * s * 0.7,
+            ay + Math.sin(angle - 2.4) * s * 0.7);
         ctx.closePath();
         ctx.fill();
 
-        // small distance line behind arrowhead
         ctx.beginPath();
-        ctx.moveTo(ax - dx * 6, ay - dy * 6);
+        ctx.moveTo(ax - dx * 6,  ay - dy * 6);
         ctx.lineTo(ax - dx * 20, ay - dy * 20);
         ctx.stroke();
     }

--- a/webGL/js/controls/WeaponsCollisionManager.js
+++ b/webGL/js/controls/WeaponsCollisionManager.js
@@ -5,17 +5,12 @@ export default (weapons, userId, scene, sceneConstants) => {
     function checkCollision(sceneObjects) {
         for(let i=0; i<weapons.length; i++) {
             sceneObjects.forEach(obj => {
-                // checkCollision with weapons with scene objects
                 if(obj && obj.mesh){
-                    // skip destroyed ships
-                    if(obj.mesh.hull <= 0) return;
-                    // console.log(`checking mesh collision: ${obj.mesh.name}`);
                     const collisionCheck = weapons[i].checkCollision(obj.mesh);
                     if(collisionCheck.collision){
-                        // console.log(`lasers collided with ${obj.mesh.name}`);
-                        // console.log(`trigger: explosion at ${JSON.stringify(obj.mesh.position)}`);
-                        // trigger explosion
-                        triggerEvent(sceneObjects, obj, eventType.EXPLOSION);
+                        // use actual hit point if available, fall back to mesh position
+                        const hitPosition = collisionCheck.hitPoint || obj.mesh.position;
+                        triggerEvent(sceneObjects, obj, eventType.EXPLOSION, hitPosition);
                         return true;
                     }
                 }
@@ -38,17 +33,13 @@ export default (weapons, userId, scene, sceneConstants) => {
         mesh.shields = Math.max(0, mesh.shields);
     }
 
-    function triggerEvent(sceneObjects, obj, event) {
+    function triggerEvent(sceneObjects, obj, event, hitPosition) {
         for(let i=0; i<sceneObjects.length; i++){
             if(event === eventType.EXPLOSION && sceneObjects[i].name === event){
-                // skip if already destroyed
-                if(obj.mesh.hull <= 0) return;
-
                 const isPlayer = obj.mesh.userId === userId;
 
                 applyDamage(obj.mesh, 25);
 
-                // if this is the player's ship, broadcast for the HUD
                 if(isPlayer) {
                     eventBus.post(eventType.PLAYER_DAMAGED, {
                         shields: obj.mesh.shields,
@@ -57,18 +48,18 @@ export default (weapons, userId, scene, sceneConstants) => {
                         maxHull: obj.mesh.maxHull,
                     });
                 } else {
-                    // notify HUD in case this ship is the current target
                     eventBus.post(eventType.TARGET_DAMAGED, {
                         shields: obj.mesh.shields,
                         maxShields: obj.mesh.maxShields,
                         hull: obj.mesh.hull,
                         maxHull: obj.mesh.maxHull,
-                        userId: obj.mesh.userId,        // use userId instead of designation
+                        userId: obj.mesh.userId,
                         designation: obj.mesh.designation,
                     });
                 }
 
-                sceneObjects[i].trigger(obj.mesh.position);
+                // trigger explosion at actual hit point
+                sceneObjects[i].trigger(hitPosition);
                 // console.log(`Update ${obj.mesh.name} Hull: ${obj.mesh.hull}`);
 
                 if(obj.mesh.hull <= 0){

--- a/webGL/js/sceneSubjects/weapons/LaserCannons.js
+++ b/webGL/js/sceneSubjects/weapons/LaserCannons.js
@@ -115,9 +115,12 @@ function Laser(scene, sourceShipMesh, numberOfLasers, config, collisionManager, 
                     (laser.laser.position.z >= (pos.z - spread) && laser.laser.position.z <= (pos.z + spread))
                 ) {
                     cleanup(laser.laser, i);
-                    collisionRes = { collision: true, name: 'Laser-hit' };
+                    collisionRes = {
+                        collision: true,
+                        name: 'Laser-hit',
+                        hitPoint: laser.laser.position.clone() // laser position as fallback
+                    };
                 }
-                return;
             }
 
             // first do a fast Box3 pre-check to avoid expensive raycasting
@@ -153,7 +156,12 @@ function Laser(scene, sourceShipMesh, numberOfLasers, config, collisionManager, 
             if(intersects.length > 0) {
                 console.log(`precise laser HIT ${name}: ${id} at distance ${intersects[0].distance}`);
                 cleanup(laser.laser, i);
-                collisionRes = { collision: true, name: 'Laser-hit' };
+                // return the actual world-space hit point
+                collisionRes = {
+                    collision: true,
+                    name: 'Laser-hit',
+                    hitPoint: intersects[0].point.clone()
+                };
             }
         });
 

--- a/webGL/js/utils/ModelLoader.js
+++ b/webGL/js/utils/ModelLoader.js
@@ -27,6 +27,7 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
     let cm;
     let modelReady = false;
     let lastTime = 0;
+    let skyBox = null;
     cm = collisionManager;
     const group = new THREE.Group();
     group.hull = modelConfiguration.hull;
@@ -41,11 +42,10 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
 
     if(modelGltf) {
         configureGLTFObject(modelGltf);
-
     } else {
         loadGLTFModel(Model[modelConfiguration.name]);
     }
-    // change the guard to only exclude ISD
+
     if(!modelConfiguration.playerName && collisionManager && audio && laser
         && modelConfiguration.name !== 'ISD' && modelConfiguration.name !== 'TRANSPORT') {
         if(modelConfiguration.name === 'SHUTTLE') {
@@ -76,7 +76,6 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
 
         function distanceTo(meshA, meshB) {
             if(!meshA || !meshB) return Infinity;
-            // for the ISD use its visual center not group origin
             if(meshB.name === 'ISD') {
                 const center = getISDCenter(meshB);
                 return meshA.position.distanceTo(center);
@@ -103,12 +102,10 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
             const center = getISDCenter(isd);
             const size   = getISDSize(isd);
 
-            // orbit radius based on actual ship size — stay outside the hull
             const safeRadiusX = (size.x / 2) + 60;
             const safeRadiusZ = (size.z / 2) + 60;
             const safeRadiusY = (size.y / 2) + 30;
 
-            // pick a random angle around the ship
             const angle = Math.random() * Math.PI * 2;
 
             return new THREE.Vector3(
@@ -123,7 +120,6 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
             const center = getISDCenter(isd);
             const size   = getISDSize(isd);
 
-            // form up at a safe distance from the ship
             const angle = Math.random() * Math.PI * 2;
             const radius = (Math.max(size.x, size.z) / 2) + 100;
 
@@ -132,6 +128,59 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
                 center.y + (Math.random() - 0.5) * 40,
                 center.z + Math.sin(angle) * radius
             );
+        }
+
+        // ── ship-to-ship collision ────────────────────────────────
+        function checkShipCollision(modelGroup) {
+            const myBox = new THREE.Box3().setFromObject(modelGroup);
+            myBox.expandByScalar(-2);
+
+            let collision = false;
+            let collisionNormal = null;
+
+            scene.children.forEach(child => {
+                if(child === modelGroup) return;
+                if(!child.userId && !child.designation) return;
+                if(child.hull <= 0) return;
+                if(child.name === 'EXPLOSION') return;
+
+                const otherBox = new THREE.Box3().setFromObject(child);
+                otherBox.expandByScalar(-2);
+
+                if(myBox.intersectsBox(otherBox)) {
+                    const myCenter    = new THREE.Vector3();
+                    const otherCenter = new THREE.Vector3();
+                    myBox.getCenter(myCenter);
+                    otherBox.getCenter(otherCenter);
+
+                    collisionNormal = new THREE.Vector3()
+                        .subVectors(myCenter, otherCenter)
+                        .normalize();
+
+                    collision = true;
+                }
+            });
+
+            return { collision, collisionNormal };
+        }
+
+        function handleShipCollision(newWaypoint) {
+            const shipCollision = checkShipCollision(modelGroup);
+            if(!shipCollision.collision || !shipCollision.collisionNormal) return false;
+
+            modelGroup.position.addScaledVector(shipCollision.collisionNormal, modelConfiguration.speed * 2);
+
+            if(modelConfiguration.flight && modelConfiguration.flight.velocity) {
+                const v = modelConfiguration.flight.velocity;
+                const dot = v.dot(shipCollision.collisionNormal);
+                v.addScaledVector(shipCollision.collisionNormal, -2 * dot);
+                v.x += (Math.random() - 0.5) * 0.1;
+                v.z += (Math.random() - 0.5) * 0.1;
+                v.setLength(modelConfiguration.speed);
+            }
+
+            if(newWaypoint) attackWaypoint = newWaypoint;
+            return true;
         }
 
         const FORM_RANGE     = 250;
@@ -147,29 +196,27 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
 
         fsm = new FiniteStateMachine({
 
-            // fly toward ISD in formation
             form: {
                 enter: () => {
                     console.log(`${modelGroup.designation} entering FORM`);
-                    // reset flight state so momentum starts fresh
                     modelConfiguration.flight = null;
                 },
                 update: () => {
                     const isd = getISD();
                     if(!isd) return;
 
-                    const formTarget = getFormWaypoint(isd);
+                    if(handleShipCollision(null)) return;
+
                     const collision = NpcControls(scene, modelGroup, modelConfiguration, "flightUpdate", -1, cm, audio, laser, isd);
 
                     if(collision) {
-                        // nudge back toward ISD on boundary hit
                         modelGroup.position.add(
                             new THREE.Vector3()
                                 .subVectors(isd.position, modelGroup.position)
                                 .normalize()
                                 .multiplyScalar(modelConfiguration.speed * 2)
                         );
-                        modelConfiguration.flight = null; // reset momentum
+                        modelConfiguration.flight = null;
                     }
 
                     if(distanceTo(modelGroup, isd) < FORM_RANGE) {
@@ -190,6 +237,8 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
                     const player = getPlayer();
                     if(!isd) return;
 
+                    if(handleShipCollision(getAttackWaypoint(isd))) return;
+
                     if(player && distanceTo(modelGroup, player) < THREAT_RANGE && Date.now() > evadeCooldownUntil) {
                         fsm.transition("evade");
                         return;
@@ -206,15 +255,13 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
                                 .normalize()
                                 .multiplyScalar(modelConfiguration.speed * 2)
                         );
-                        modelConfiguration.flight = null; // reset momentum on wall hit
+                        modelConfiguration.flight = null;
                     }
 
-                    // fire when close to ISD
                     if(distanceTo(modelGroup, isd) < ATTACK_RANGE) {
                         NpcControls(scene, modelGroup, modelConfiguration, "burstFire", -1, cm, audio, laser);
                     }
 
-                    // pick new overshoot waypoint when close to current one
                     if(attackWaypoint && modelGroup.position.distanceTo(attackWaypoint) < 20) {
                         attackWaypoint = getAttackWaypoint(isd);
                     }
@@ -226,12 +273,11 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
                     console.log(`${modelGroup.designation} entering EVADE`);
                     evadeTimer = Date.now() + EVADE_DURATION;
                     const player = getPlayer();
-                    // fly directly away from player with some vertical variation
                     if(player) {
                         const away = new THREE.Vector3()
                             .subVectors(modelGroup.position, player.position)
                             .normalize();
-                        away.y += (Math.random() - 0.5) * 0.5; // add vertical variation
+                        away.y += (Math.random() - 0.5) * 0.5;
                         away.normalize();
                         evadeTarget = modelGroup.position.clone().add(away.multiplyScalar(100));
                     } else {
@@ -243,9 +289,11 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
                             )
                         );
                     }
-                    modelConfiguration.flight = null; // reset momentum for sharp evasion
+                    modelConfiguration.flight = null;
                 },
                 update: () => {
+                    if(handleShipCollision(null)) return;
+
                     const collision = NpcControls(scene, modelGroup, modelConfiguration, "flightUpdate", -1, cm, audio, laser, evadeTarget);
 
                     if(collision) {
@@ -263,11 +311,13 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
                 enter: () => {
                     console.log(`${modelGroup.designation} entering RETURN_TO_ATTACK`);
                     evadeCooldownUntil = Date.now() + EVADE_COOLDOWN;
-                    modelConfiguration.flight = null; // reset momentum
+                    modelConfiguration.flight = null;
                 },
                 update: () => {
                     const isd = getISD();
                     if(!isd) return;
+
+                    if(handleShipCollision(null)) return;
 
                     const collision = NpcControls(scene, modelGroup, modelConfiguration, "flightUpdate", -1, cm, audio, laser, isd);
 
@@ -287,7 +337,6 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
                 }
             },
 
-            // keep old states so nothing breaks
             patrol: {
                 enter: () => {},
                 update: () => {
@@ -327,31 +376,27 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
 
         const PATROL_DISTANCE  = 1000;
         const ARRIVE_THRESHOLD = 20;
-        const DOCK_WAIT        = 20000; // 20 seconds
+        const DOCK_WAIT        = 20000;
 
-        let waypointA       = null;
-        let waypointB       = null;
-        let dockTimer       = 0;
+        let waypointA = null;
+        let waypointB = null;
+        let dockTimer = 0;
 
-        // positions relative to ISD
-        function getPatrolY(isd) { return isd.position.y - 20; }  // patrol height
-        function getDockY(isd)   { return isd.position.y + 30;  }  // risen Y toward ISD underside
-        function getPatrolZ(isd) { return isd.position.z - 20; }  // patrol Z — unchanged
+        function getPatrolY(isd) { return isd.position.y - 20; }
+        function getDockY(isd)   { return isd.position.y + 30; }
+        function getPatrolZ(isd) { return isd.position.z - 20; }
 
         function initWaypoints() {
             const isd = getISD();
             if(!isd || waypointA) return;
             const y = getPatrolY(isd);
             const z = getPatrolZ(isd);
-            // waypointA — far out on positive X
             waypointA = new THREE.Vector3(isd.position.x + PATROL_DISTANCE, y, z);
-            // waypointB — directly under ISD at patrol Z
-            waypointB = new THREE.Vector3(isd.position.x - 15, y, z-80);
+            waypointB = new THREE.Vector3(isd.position.x - 15, y, z - 80);
         }
 
         function seedVelocityToward(target) {
             if(!target) { modelConfiguration.flight = null; return; }
-            // only seed if no flight state exists yet — otherwise let momentum carry
             if(!modelConfiguration.flight) {
                 const targetPos = target.isVector3 ? target : target.position;
                 const toTarget = new THREE.Vector3()
@@ -364,14 +409,10 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
 
         fsm = new FiniteStateMachine({
 
-            // ── DEPART ───────────────────────────────────────────────
-            // fly out to waypointA
             depart: {
                 enter: () => {
                     console.log(`${modelGroup.designation} SHUTTLE entering DEPART`);
-                    console.log(`${modelGroup.designation} x: ${modelGroup.position.x}, y:${modelGroup.position.y}, z: ${modelGroup.position.z}`);
                     initWaypoints();
-                    // only seed on very first load when there is no flight state at all
                     if(!modelConfiguration.flight) {
                         seedVelocityToward(waypointA);
                     }
@@ -400,7 +441,6 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
                 enter: () => {
                     console.log(`${modelGroup.designation} SHUTTLE entering RETURN`);
                     initWaypoints();
-                    // only seed if no flight state — let momentum carry into the turn
                     seedVelocityToward(waypointB);
                 },
                 update: () => {
@@ -422,8 +462,6 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
                 }
             },
 
-            // ── SLOW DOWN ────────────────────────────────────────────
-            // bleed off speed to a stop under the ISD
             slowDown: {
                 enter: () => {
                     console.log(`${modelGroup.designation} SHUTTLE entering SLOW_DOWN`);
@@ -441,7 +479,6 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
                     if(newSpeed > 0.01) {
                         f.velocity.setLength(newSpeed);
 
-                        // smooth yaw while slowing
                         const targetYaw = Math.atan2(f.velocity.x, f.velocity.z) + Math.PI;
                         let yawDiff = targetYaw - modelGroup.rotation.y;
                         while(yawDiff >  Math.PI) yawDiff -= Math.PI * 2;
@@ -456,12 +493,10 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
                 }
             },
 
-            // ── RISE ─────────────────────────────────────────────────
-            // rise on Z axis toward ISD underside and slowly rotate
             rise: {
                 enter: () => {
                     console.log(`${modelGroup.designation} SHUTTLE entering RISE`);
-                    wingsUp(); // raise wings as shuttle rises to dock
+                    wingsUp();
                     if(!modelConfiguration.flight) {
                         modelConfiguration.flight = { velocity: new THREE.Vector3(0,0,0), currentBank: 0 };
                     }
@@ -471,11 +506,10 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
                     const isd = getISD();
                     if(!isd) return;
 
-                    // rise target — same X and Y, Z moves toward ISD
                     const riseTarget = new THREE.Vector3(
                         isd.position.x,
-                        getDockY(isd),   // rise on Y toward ISD underside
-                        (getPatrolZ(isd) - 80)  // Z stays at patrol level
+                        getDockY(isd),
+                        getPatrolZ(isd) - 80
                     );
 
                     const dist = modelGroup.position.distanceTo(riseTarget);
@@ -488,7 +522,6 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
                         modelGroup.position.add(step);
                     }
 
-                    // slowly rotate to docking orientation
                     let yawDiff = 0 - modelGroup.rotation.y;
                     while(yawDiff >  Math.PI) yawDiff -= Math.PI * 2;
                     while(yawDiff < -Math.PI) yawDiff += Math.PI * 2;
@@ -502,8 +535,6 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
                 }
             },
 
-            // ── DOCKED ───────────────────────────────────────────────
-            // sit still for 20 seconds
             docked: {
                 enter: () => {
                     console.log(`${modelGroup.designation} SHUTTLE entering DOCKED`);
@@ -513,16 +544,12 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
                     }
                 },
                 update: () => {
-                    // hold position — no movement
                     if(Date.now() > dockTimer) {
                         fsm.transition("lower");
                     }
                 }
             },
 
-            // ── LOWER ────────────────────────────────────────────────
-            // descend back on Z axis to patrol Z before departing
-            // ── LOWER ────────────────────────────────────────────────
             lower: {
                 enter: () => {
                     console.log(`${modelGroup.designation} SHUTTLE entering LOWER`);
@@ -530,7 +557,7 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
                         modelConfiguration.flight = { velocity: new THREE.Vector3(0,0,0), currentBank: 0 };
                     }
                     modelConfiguration.flight.velocity.set(0, 0, 0);
-                    wingsDown(); // lower wings before departing
+                    wingsDown();
                 },
                 update: () => {
                     const isd = getISD();
@@ -552,15 +579,30 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
                         modelGroup.position.add(step);
                     }
 
+                    // rotate toward waypointA while lowering
+                    if(waypointA) {
+                        const toWaypoint = new THREE.Vector3()
+                            .subVectors(waypointA, modelGroup.position)
+                            .normalize();
+                        const targetYaw = Math.atan2(toWaypoint.x, toWaypoint.z);
+                        let yawDiff = targetYaw - modelGroup.rotation.y;
+                        while(yawDiff >  Math.PI) yawDiff -= Math.PI * 2;
+                        while(yawDiff < -Math.PI) yawDiff += Math.PI * 2;
+                        modelGroup.rotation.y += yawDiff * 0.012;
+                    }
+
                     if(dist < 2) {
-                        modelConfiguration.flight = { velocity: new THREE.Vector3(0,0,0), currentBank: 0 };
+                        const facingMatrix = new THREE.Matrix4().extractRotation(modelGroup.matrix);
+                        const facingDir = new THREE.Vector3(0, 0, -1).applyMatrix4(facingMatrix);
+                        modelConfiguration.flight = {
+                            velocity: facingDir.multiplyScalar(modelConfiguration.speed * 0.3),
+                            currentBank: 0
+                        };
                         fsm.transition("turnToDepart");
                     }
                 }
             },
 
-            // ── TURN TO DEPART ───────────────────────────────────────
-            // rotate in place to face waypointA before departing
             turnToDepart: {
                 enter: () => {
                     console.log(`${modelGroup.designation} SHUTTLE entering TURN_TO_DEPART`);
@@ -568,23 +610,18 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
                 update: () => {
                     if(!waypointA) return;
 
-                    // calculate angle to waypointA
                     const toWaypoint = new THREE.Vector3()
                         .subVectors(waypointA, modelGroup.position)
                         .normalize();
                     const targetYaw = Math.atan2(toWaypoint.x, toWaypoint.z);
 
-                    // find shortest angle difference
                     let yawDiff = targetYaw - modelGroup.rotation.y;
                     while(yawDiff >  Math.PI) yawDiff -= Math.PI * 2;
                     while(yawDiff < -Math.PI) yawDiff += Math.PI * 2;
 
-                    // rotate slowly in place
                     modelGroup.rotation.y += yawDiff * 0.02;
 
-                    // once close enough to facing waypointA — start flying
                     if(Math.abs(yawDiff) < 0.05) {
-                        // seed velocity in exact direction we are now facing
                         const facingMatrix = new THREE.Matrix4().extractRotation(modelGroup.matrix);
                         const facingDir = new THREE.Vector3(0, 0, -1).applyMatrix4(facingMatrix);
                         modelConfiguration.flight = {
@@ -598,12 +635,7 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
 
         }, "depart");
     }
-    /**
-     * loadGLTFModel
-     * @description this will load the GLTF model
-     * from file and sets it up
-     * @param modelGltf
-     */
+
     function loadGLTFModel(modelGltf) {
         loader = new GLTFLoader();
         loader.load(modelGltf, function(gltf, err) {
@@ -617,20 +649,13 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
             root.scale.z = modelConfiguration.scale;
             root.name = modelConfiguration.name;
             if(gltf.animations.length > 0){
-               animations(gltf);
+                animations(gltf);
             }
             modelReady = true;
             group.add(root);
         });
     }
 
-    /**
-     * configureGLTFObject
-     * @description this takes a gltf model already loaded
-     * by the manager and configures it before adding it to the group which
-     * has already been added to the scene
-     * @param modelGltf
-     */
     function configureGLTFObject(modelGltf) {
         const root = modelGltf.scene;
         root.rotation.y = modelConfiguration.rotation.y;
@@ -648,13 +673,10 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
 
     function animations(gltf) {
         mixer = new THREE.AnimationMixer(gltf.scene);
-        // clips = modelGltf.animations;
         clip = THREE.AnimationClip.findByName(gltf.animations, 'Take 01');
         action = mixer.clipAction(clip);
-        // action.loop = THREE.LoopRepeat;
         action.clampWhenFinished = true;
         action.timeScale = 1/15;
-        // action.play();
     }
 
     function wingsDown() {
@@ -662,12 +684,11 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
         if(!mixer || !action || !clip) return;
         action.stop();
         action.reset();
-        action.timeScale = 1;      // play at normal speed
+        action.timeScale = 1;
         action.loop = THREE.LoopOnce;
         action.clampWhenFinished = true;
         action.play();
 
-        // pause at halfway through the clip
         const halfTime = (clip.duration / 2) * 1000;
         setTimeout(() => {
             if(action) {
@@ -682,13 +703,12 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
         if(!mixer || !action || !clip) return;
         action.stop();
         action.reset();
-        action.timeScale = 1;              // play forward
+        action.timeScale = 1;
         action.loop = THREE.LoopOnce;
         action.clampWhenFinished = true;
-        action.time = clip.duration / 2;  // start from halfway — wings down position
+        action.time = clip.duration / 2;
         action.play();
 
-        // pause at end of clip — wings fully up
         const halfTime = (clip.duration / 2) * 1000;
         setTimeout(() => {
             if(action) {


### PR DESCRIPTION
 ## Summary
  - Add a Node built-in-test-runner integration suite (server/test/integration.test.js) that boots the real server on a scratch port and
  verifies it end-to-end over HTTP/Socket.IO (index page, client JS, CSS, a ship model, and the Socket.IO handshake)
  - Wire it up as `npm test` at both the server and root package.json level
  - Add CLAUDE.md documenting the codebase architecture for future coding sessions
  - Add a short Testing section to README.md

  ## Test plan
  - [x] `npm test` from repo root passes all 7 checks
  - [x] Confirmed the spawned test server process is cleanly killed afterward (no leftover process on the scratch port)