### PR TITLE
Add Playwright end-to-end smoke tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 
 /node_modules/
 /.idea
+
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/e2e/smoke.spec.js
+++ b/e2e/smoke.spec.js
@@ -1,0 +1,21 @@
+const { test, expect } = require('@playwright/test');
+
+test('loads the main menu with no console errors', async ({ page }) => {
+    const pageErrors = [];
+    page.on('pageerror', err => pageErrors.push(err.message));
+
+    await page.goto('/');
+
+    await expect(page.locator('.menu-title')).toHaveText('IMPERIAL COMBAT SIMULATOR');
+    await expect(page.locator('#canvas')).toBeVisible();
+    expect(pageErrors).toEqual([]);
+});
+
+test('selecting multiplayer reveals the ship-select sub-menu', async ({ page }) => {
+    await page.goto('/');
+
+    await page.locator('.menu-item[name="shipselect"]').click();
+
+    await expect(page.locator('#sub-menu')).toBeVisible();
+    await expect(page.locator('#menu')).toBeHidden();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "license": "ISC",
       "dependencies": {
         "pm2": "^4.5.0"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.61.1"
       }
     },
     "node_modules/@opencensus/core": {
@@ -68,6 +71,21 @@
       "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "bin": {
         "semver": "bin/semver"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@pm2/agent": {
@@ -1192,6 +1210,36 @@
         }
       ]
     },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/pm2": {
       "version": "4.5.6",
       "resolved": "https://registry.npmjs.org/pm2/-/pm2-4.5.6.tgz",
@@ -1750,6 +1798,15 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
           "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g=="
         }
+      }
+    },
+    "@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "requires": {
+        "playwright": "1.61.1"
       }
     },
     "@pm2/agent": {
@@ -2623,6 +2680,22 @@
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
+    },
+    "playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2",
+        "playwright-core": "1.61.1"
+      }
+    },
+    "playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true
     },
     "pm2": {
       "version": "4.5.6",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "cd server && npm test",
+    "test:e2e": "playwright test",
     "build": "cd server && npm i && cd .. && cd webGL && npm i",
     "start": "node server/src/main.js"
   },
@@ -20,5 +21,8 @@
   "homepage": "https://github.com/sandman45/TieFighter#readme",
   "dependencies": {
     "pm2": "^4.5.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.61.1"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,27 @@
+const { defineConfig } = require('@playwright/test');
+
+// Scratch port so this doesn't collide with a server you already have running locally.
+const PORT = process.env.E2E_WEB_SERVER_PORT || 3060;
+
+module.exports = defineConfig({
+    testDir: './e2e',
+    timeout: 30000,
+    fullyParallel: false,
+    reporter: 'list',
+    webServer: {
+        command: 'node main.js',
+        cwd: 'server/src',
+        url: `http://localhost:${PORT}/`,
+        env: { WEB_SERVER: String(PORT) },
+        reuseExistingServer: !process.env.CI,
+        timeout: 15000
+    },
+    use: {
+        baseURL: `http://localhost:${PORT}`,
+        screenshot: 'only-on-failure',
+        launchOptions: {
+            // headless chromium needs a software GL fallback to create a WebGL context
+            args: ['--use-gl=angle', '--use-angle=swiftshader', '--ignore-gpu-blocklist']
+        }
+    }
+});


### PR DESCRIPTION
## Summary
- Add `@playwright/test` (+ Chromium binary) as a dev dependency
- Add `playwright.config.js`, which spawns the real server (`server/src/main.js`) on a scratch port (3060) as Playwright's `webServer`, with a software-GL launch flag so WebGL works headlessly
- Add `e2e/smoke.spec.js`: loads the main menu with no console errors, and verifies clicking "MULTI-PLAYER" reveals the ship-select sub-menu
- Wire it up as `npm run test:e2e`
- Ignore `test-results/`, `playwright-report/`, `playwright/.cache/` in `.gitignore`

## Test plan
- [x] `npx playwright test` passes both smoke tests locally
- [x] Confirmed the scratch-port server Playwright spawns is cleanly shut down after the run