### PR TITLE
Increase reading-text font sizes for readability

### DIFF
--- a/webGL/css/menu.css
+++ b/webGL/css/menu.css
@@ -165,7 +165,7 @@
     padding-bottom: 20px;
     visibility: hidden;
     display: flex;
-    height: 40%;
+    height: 52%;
     width: 80%;
     gap: 12px;
 }
@@ -181,7 +181,7 @@
 
 .ship-info-left h5 {
     font-family: var(--font-title);
-    font-size: 11px;
+    font-size: 13px;
     letter-spacing: 3px;
     color: var(--green);
     text-shadow: 0 0 8px var(--green);
@@ -193,14 +193,14 @@
 .ship-info-left p {
     display: block;
     font-family: var(--font-mono);
-    font-size: 9px;
+    font-size: 12px;
     line-height: 1.7;
     color: var(--text-dim);
     margin-bottom: 8px;
 }
 
 .ship-info-left img {
-    height: 160px;
+    height: 130px;
     filter: drop-shadow(0 0 8px rgba(0,204,68,0.4));
     display: block;
     margin: 10px auto 0;

--- a/webGL/css/missionBriefing.css
+++ b/webGL/css/missionBriefing.css
@@ -184,7 +184,7 @@
     margin-bottom: 6px;
 }
 .officer-speech {
-    font-size: 9px;
+    font-size: 12px;
     color: var(--text-dim);
     line-height: 1.5;
     font-style: italic;
@@ -214,7 +214,7 @@
     flex: 1;
     overflow-y: auto;
     padding: 10px 12px;
-    font-size: 10px;
+    font-size: 13px;
     line-height: 1.8;
     color: var(--text);
     scrollbar-width: thin;


### PR DESCRIPTION
## Summary
- Mission briefing body text (`.briefing-text`) and the officer's spoken quote (`.officer-speech`) bumped from 10px/9px to 13px/12px
- Multiplayer ship-select info panel description (`.ship-info-left p`) bumped from 9px to 12px, and its title bumped from 11px to 13px so it stays larger than the now-bigger body text
- Grew `#shipInfo`'s container height (40% → 52% of viewport) and shrank the ship render (160px → 130px) to make room — the larger paragraph text no longer fit the old fixed-height box and was clipping the bottom of the ship image
- Menu items, buttons, and small section labels (briefing topics list, HUD, nav buttons, etc.) intentionally left untouched per request

## Test plan
- [x] `npm run test:e2e` — all 4 tests pass
- [x] Manually verified via Playwright screenshots: ship-select info panel (multiple ships, image no longer clipped) and mission briefing screen (situation report + objectives tabs) both render cleanly with no overflow