### PR TITLE
Update README and remove strafe/arrow-key flight controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 # Tie Fighter
 
-Creating a Tie Fighter game using [PierfrancescoSoffritti's Configurable Three JS App template](https://github.com/PierfrancescoSoffritti/configurable-threejs-app). Check it out 
-he has done an amazing job. 
+A Star Wars TIE Fighter browser game: a Three.js (WebGL) client with
+single-player campaign missions and a Socket.IO-based multiplayer mode,
+backed by a small Node/Express real-time server.
+
+Built starting from [PierfrancescoSoffritti's Configurable Three JS App
+template](https://github.com/PierfrancescoSoffritti/configurable-threejs-app) —
+check it out, he's done an amazing job.
 
 * early version
 
@@ -11,59 +16,83 @@ he has done an amazing job.
 
 ![Tie Fighter Game](tie-fighter-game-2.gif)
 
-### Play it here http://tie-fighter.mattsanders.org
+### Play it here: https://tie-fighter.mattsanders.org
 
-or run it locally
+or run it locally:
 
 ## How to start
 
 ### Install
 
-To use this project you need to download all the required modules from npm, to do that run this commands from the root folder of the project
+This repo has two independent npm packages, `server/` and `webGL/`. Install
+both from the repo root:
 
 ```
-cd server
-npm install
+npm run build
 ```
 
-```
-cd WebGL
-npm install
-```
+On Windows you can also just double-click/run `install.bat`, which does the
+same thing.
 
-create a `.env` file in the `/server/src/` directory
+Create a `.env` file in `server/src/` (gitignored, not committed):
+
 ```
 WEB_SERVER=3000
 ```
 
 ### Launch the server
 
-To start the server run this command, from the root folder of the project
+From the repo root:
 
 ```
-cd server
-cd src
+cd server/src
 node main
 ```
-### Running on Webstorm
 
-```
-click run main.js node
-```
+The server must be started from inside `server/src` — it resolves the
+`webGL/` static assets relative to its own directory.
 
-server will run port 3000 unless you change the port in the .env file
+In WebStorm you can instead just right-click `server/src/main.js` and
+choose "Run".
 
-the web server will run on port 3000 unless changed in the .env file
+The game will be available at `http://localhost:3000/` (or whatever port
+you set `WEB_SERVER` to).
 
-The webpage will be available at `http://localhost:8080/`
+### Controls
+
+- **Mouse** — move to steer (no need to hold a button), click to fire lasers
+  (limited energy pool that recharges over time)
+- **W / S** — throttle up / down
+- **Q / E** — roll
+- **T** — cycle target
+- **G** — dock (when near a friendly ship that accepts docking)
 
 ### Testing
 
-Run the integration test suite from the root folder of the project
+Run the server integration test suite from the repo root:
 
 ```
 npm test
 ```
 
-This spawns the real server on a scratch port and checks it over HTTP/Socket.IO the same way a browser would (index page, client JS, CSS, a ship model, and the Socket.IO handshake). It uses Node's built-in test runner, so no extra install is needed.
+This spawns the real server on a scratch port and hits it over HTTP/Socket.IO
+the same way a browser would (index page, client JS, CSS, a ship model, and
+the Socket.IO handshake). It uses Node's built-in test runner, so no extra
+install is needed.
 
+There's also a Playwright end-to-end suite that drives the game in a real
+browser (menu navigation, mission objectives, etc.):
+
+```
+npm run test:e2e
+```
+
+It boots its own server instance on a scratch port, so you don't need the
+dev server running first.
+
+## More docs
+
+- [`server/README.md`](server/README.md) — deployment notes for the
+  Node server.
+- [`infra/README.md`](infra/README.md) — Terraform-managed AWS deployment
+  and CI/CD.

--- a/webGL/js/controls/FlyControls.js
+++ b/webGL/js/controls/FlyControls.js
@@ -57,16 +57,10 @@ export default class FlyControls {
         this.mouseStatus = 0;
 
         this.moveState = {
-            up: 0,
-            down: 0,
-            left: 0,
-            right: 0,
             forward: 0,
             back: 0,
-            pitchUp: 0,
             pitchDown: 0,
             yawLeft: 0,
-            yawRight: 0,
             rollLeft: 0,
             rollRight: 0
         };
@@ -132,13 +126,11 @@ export default class FlyControls {
 
     updateMovementVector = function() {
         const forward = ( this.moveState.forward || ( this.autoForward && ! this.moveState.back ) ) ? 1 : 0;
-        this.moveVector.x = ( - this.moveState.left    + this.moveState.right );
-        this.moveVector.y = ( - this.moveState.down    + this.moveState.up );
         this.moveVector.z = ( - forward + this.moveState.back );
     };
     updateRotationVector = function() {
-        this.rotationVector.x = ( - this.moveState.pitchDown + this.moveState.pitchUp );
-        this.rotationVector.y = ( - this.moveState.yawRight  + this.moveState.yawLeft );
+        this.rotationVector.x = - this.moveState.pitchDown;
+        this.rotationVector.y = this.moveState.yawLeft;
         this.rotationVector.z = ( - this.moveState.rollRight + this.moveState.rollLeft );
     };
 
@@ -174,18 +166,6 @@ export default class FlyControls {
             case 87: /*W*/ this.throttleUp(); break;
             case 83: /*S*/ this.throttleDown(); break;
 
-            case 65: /*A*/ this.moveState.left = 1; break;
-            case 68: /*D*/ this.moveState.right = 1; break;
-
-            case 82: /*R*/ this.moveState.up = 1; break;
-            case 70: /*F*/ this.moveState.down = 1; break;
-
-            case 38: /*up*/ this.moveState.pitchUp = 1; break;
-            case 40: /*down*/ this.moveState.pitchDown = 1; break;
-
-            case 37: /*left*/ this.moveState.yawLeft = 1; break;
-            case 39: /*right*/ this.moveState.yawRight = 1; break;
-
             case 81: /*Q*/ this.moveState.rollLeft = 1; break;
             case 69: /*E*/ this.moveState.rollRight = 1; break;
             case 187: /*+/=*/
@@ -210,18 +190,6 @@ export default class FlyControls {
 
             case 87: /*W*/  break;
             case 83: /*S*/  break;
-
-            case 65: /*A*/ this.moveState.left = 0; break;
-            case 68: /*D*/ this.moveState.right = 0; break;
-
-            case 82: /*R*/ this.moveState.up = 0; break;
-            case 70: /*F*/ this.moveState.down = 0; break;
-
-            case 38: /*up*/ this.moveState.pitchUp = 0; break;
-            case 40: /*down*/ this.moveState.pitchDown = 0; break;
-
-            case 37: /*left*/ this.moveState.yawLeft = 0; break;
-            case 39: /*right*/ this.moveState.yawRight = 0; break;
 
             case 81: /*Q*/ this.moveState.rollLeft = 0; break;
             case 69: /*E*/ this.moveState.rollRight = 0; break;
@@ -399,8 +367,6 @@ export default class FlyControls {
         });
         if(!collision){
             this.autoForward = true;
-            this.object.translateX( this.moveVector.x * moveMult );
-            this.object.translateY( this.moveVector.y * moveMult );
             this.object.translateZ( this.moveVector.z * moveMult );
             if(this.moveState.forward === 1) {
                 let flyType = "FLYBY";


### PR DESCRIPTION
## Summary
- Rewrite the root `README.md`: fix the wrong local port in "webpage available at" (said 8080, server actually runs on 3000 per `.env`), fix `cd WebGL` → `cd webGL` casing, document the root `npm run build` install path and `install.bat`, add a Controls section, document the Playwright e2e suite alongside the existing integration test docs, link out to `server/README.md` and `infra/README.md`, and switch the play-it-here link to https.
- `FlyControls.js`: remove the A/D/R/F strafe controls and the arrow-key pitch/yaw bindings. Mouse movement already continuously drives pitch/yaw (`dragToLook` is `false` in both `MissionOne` and `MultiPlayer`), so the arrow keys were a redundant, easily-overwritten secondary input, and strafing wasn't something we want to keep. Cleaned up the now-fully-dead `moveState` fields (`left`/`right`/`up`/`down`/`pitchUp`/`yawRight`) and the `moveVector.x`/`.y` plumbing along with the key bindings.

## Test plan
- [x] Verified in a live Playwright-driven browser run: throttle, roll, mouse-look, target cycling, and firing all still work with zero console errors after the control removal; the removed keys (A/D/R/F/arrows) are confirmed harmless no-ops.
- [x] `npm test` (server integration suite) — all 7 tests pass.
- [x] Repo-wide grep confirms no leftover references to the removed `moveState` fields anywhere in `webGL/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)