### PR TITLE
Refine pilot screen: bigger fonts, pilot list, delete with confirmation

### DIFF
--- a/e2e/pilot.spec.js
+++ b/e2e/pilot.spec.js
@@ -48,9 +48,8 @@ test.describe('Pilot profile system', () => {
         await expect(page.locator('#pilot-stat-rank')).toHaveText('FLT. CADET');
         await expect(page.locator('#pilot-stat-score')).toHaveText('0');
         await expect(page.locator('#pilot-stat-missions')).toHaveText('0');
-        await expect(page.locator('#pilot-index-indicator')).toHaveText('PILOT 1 / 1');
-        await expect(page.locator('#pilotArrowLeft')).toBeDisabled();
-        await expect(page.locator('#pilotArrowRight')).toBeDisabled();
+        await expect(page.locator('.pilot-list-item')).toHaveCount(1);
+        await expect(page.locator('.pilot-list-item')).toHaveClass(/active/);
     });
 
     test('renaming persists across reload', async ({ page }) => {
@@ -67,27 +66,99 @@ test.describe('Pilot profile system', () => {
         await expect(page.locator('#pilot-name-input')).toHaveValue('TEST PILOT');
     });
 
-    test('create new pilot and cycle with wraparound', async ({ page }) => {
+    test('create new pilot and select from the list', async ({ page }) => {
         await page.goto('/');
 
+        const input = page.locator('#pilot-name-input');
+        await input.fill('');
+        await input.type('RICK');
+
         await page.locator('#pilotNewBtn').click();
-        await expect(page.locator('#pilot-index-indicator')).toHaveText('PILOT 2 / 2');
+        await page.waitForTimeout(200);
+        await input.fill('');
+        await input.type('SQUAKE');
+
+        await expect(page.locator('.pilot-list-item')).toHaveCount(2);
 
         const pilots = await page.evaluate(() => JSON.parse(localStorage.getItem('TIE_FIGHTER:PILOTS')));
         expect(pilots.length).toBe(2);
         const activeId = await page.evaluate(() => JSON.parse(localStorage.getItem('TIE_FIGHTER:ACTIVE_PILOT_ID')));
         expect(activeId).toBe(pilots[1].id);
+        await expect(page.locator('.pilot-list-item', { hasText: 'SQUAKE' })).toHaveClass(/active/);
 
-        await expect(page.locator('#pilotArrowLeft')).toBeEnabled();
-        await expect(page.locator('#pilotArrowRight')).toBeEnabled();
+        // select the other pilot from the list
+        await page.locator('.pilot-list-item', { hasText: 'RICK' }).click();
+        await expect(page.locator('#pilot-name-input')).toHaveValue('RICK');
+        await expect(page.locator('.pilot-list-item', { hasText: 'RICK' })).toHaveClass(/active/);
+        await expect(page.locator('.pilot-list-item', { hasText: 'SQUAKE' })).not.toHaveClass(/active/);
+    });
 
-        // wrap forward from pilot 2 -> pilot 1
-        await page.locator('#pilotArrowRight').click();
-        await expect(page.locator('#pilot-index-indicator')).toHaveText('PILOT 1 / 2');
+    test('delete pilot requires confirmation, deleting the only pilot reseeds a default', async ({ page }) => {
+        const pageErrors = [];
+        page.on('pageerror', err => pageErrors.push(err.message));
 
-        // wrap backward from pilot 1 -> pilot 2
-        await page.locator('#pilotArrowLeft').click();
-        await expect(page.locator('#pilot-index-indicator')).toHaveText('PILOT 2 / 2');
+        await page.goto('/');
+
+        const input = page.locator('#pilot-name-input');
+        await input.fill('');
+        await input.type('DOOMED PILOT');
+
+        // opening the confirm dialog doesn't delete anything
+        await page.locator('#pilotDeleteBtn').click();
+        await expect(page.locator('#pilot-delete-confirm')).toBeVisible();
+        await expect(page.locator('#pilot-delete-confirm-text')).toContainText('DOOMED PILOT');
+
+        // cancel leaves the pilot untouched
+        await page.locator('#pilotDeleteCancelBtn').click();
+        await expect(page.locator('#pilot-delete-confirm')).toBeHidden();
+        await expect(page.locator('#pilot-name-input')).toHaveValue('DOOMED PILOT');
+        let pilots = await page.evaluate(() => JSON.parse(localStorage.getItem('TIE_FIGHTER:PILOTS')));
+        expect(pilots.length).toBe(1);
+
+        // confirming deletes the only pilot — getPilots() auto-reseeds a fresh default
+        await page.locator('#pilotDeleteBtn').click();
+        await page.locator('#pilotDeleteConfirmBtn').click();
+        await expect(page.locator('#pilot-delete-confirm')).toBeHidden();
+        await expect(page.locator('#mission-toast')).toContainText('DELETED');
+        await expect(page.locator('#pilot-name-input')).toHaveValue('ALPHA ONE');
+        pilots = await page.evaluate(() => JSON.parse(localStorage.getItem('TIE_FIGHTER:PILOTS')));
+        expect(pilots.length).toBe(1);
+        expect(pilots[0].name).toBe('ALPHA ONE');
+
+        expect(pageErrors).toEqual([]);
+    });
+
+    test('deleting one of several pilots keeps the others', async ({ page }) => {
+        await page.goto('/');
+
+        await page.locator('#pilotNewBtn').click();
+        await page.waitForTimeout(200);
+        const input = page.locator('#pilot-name-input');
+        await input.fill('');
+        await input.type('SURVIVOR');
+
+        await page.locator('#pilotDeleteBtn').click();
+        await page.locator('#pilotDeleteConfirmBtn').click();
+        await page.waitForTimeout(200);
+
+        const pilots = await page.evaluate(() => JSON.parse(localStorage.getItem('TIE_FIGHTER:PILOTS')));
+        expect(pilots.length).toBe(1);
+        expect(pilots[0].name).toBe('ALPHA ONE');
+        await expect(page.locator('.pilot-list-item')).toHaveCount(1);
+    });
+
+    test('creating a new pilot gives clear feedback (toast + focused blank name field)', async ({ page }) => {
+        await page.goto('/');
+
+        await page.locator('#pilotNewBtn').click();
+
+        await expect(page.locator('#mission-toast')).toHaveClass(/visible/);
+        await expect(page.locator('#mission-toast')).toContainText('NEW PILOT CREATED');
+        await expect(page.locator('#pilot-name-input')).toHaveValue('');
+        await expect(page.locator('#pilot-name-input')).toHaveAttribute('placeholder', 'ENTER PILOT NAME');
+
+        const isFocused = await page.evaluate(() => document.activeElement.id === 'pilot-name-input');
+        expect(isFocused).toBe(true);
     });
 
     test('scoring flow: kills + mission complete update pilot and debrief screen', async ({ page }) => {

--- a/webGL/css/pilot.css
+++ b/webGL/css/pilot.css
@@ -6,7 +6,7 @@
 }
 
 .pilot-portrait-box {
-    width: 140px; height: 140px;
+    width: 160px; height: 160px;
     background: #010e03;
     border: 1px solid var(--border-bright);
     clip-path: polygon(12px 0%, 100% 0%, calc(100% - 12px) 100%, 0% 100%);
@@ -20,7 +20,7 @@
     background: repeating-linear-gradient(0deg, transparent, transparent 3px, rgba(0,204,68,0.04) 3px, rgba(0,204,68,0.04) 4px);
 }
 .pilot-portrait-box svg {
-    width: 90px; height: 90px;
+    width: 104px; height: 104px;
     fill: var(--green);
     filter: drop-shadow(0 0 6px var(--green));
 }
@@ -32,8 +32,60 @@
 }
 
 .pilot-portrait-arrow {
-    font-size: 12px;
-    padding: 10px 10px;
+    font-size: 15px;
+    padding: 12px 12px;
+}
+
+/* ── TWO-PANEL LAYOUT (pilot list left, database right) ── */
+.pilot-panels {
+    display: flex;
+    gap: 14px;
+    margin-top: 14px;
+    align-items: stretch;
+}
+
+/* ── PILOT LIST (left panel) ── */
+.pilot-list-panel {
+    width: 300px;
+    flex: unset;
+    display: flex;
+    flex-direction: column;
+}
+.pilot-list {
+    flex: 1;
+    min-height: 160px;
+    max-height: 220px;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-bottom: 10px;
+}
+.pilot-list-item {
+    padding: 8px 10px;
+    font-family: var(--font-mono);
+    font-size: 15px;
+    letter-spacing: 2px;
+    color: var(--text-dim);
+    border: 1px solid var(--border);
+    cursor: pointer;
+    text-transform: uppercase;
+    transition: all 0.15s ease;
+}
+.pilot-list-item:hover {
+    background: #071408;
+    border-color: var(--green);
+    color: var(--green);
+}
+.pilot-list-item.active {
+    background: #041a08;
+    border-color: var(--green);
+    color: var(--green);
+    text-shadow: 0 0 6px var(--green);
+}
+.pilot-list-item-unnamed {
+    font-style: italic;
+    opacity: 0.7;
 }
 
 /* ── PILOT NAME FIELD ── */
@@ -41,19 +93,22 @@
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 4px;
-    margin-top: 4px;
-}
-.pilot-name-label {
-    font-family: var(--font-mono);
-    font-size: 9px;
-    letter-spacing: 3px;
-    color: var(--text-dim);
 }
 .pilot-name-input-wrap {
     display: flex;
     align-items: center;
+    justify-content: center;
     gap: 2px;
+    width: 100%;
+    border-radius: 2px;
+    transition: box-shadow 0.3s ease;
+}
+.pilot-name-input-wrap.flash {
+    animation: pilot-name-flash 1.2s ease;
+}
+@keyframes pilot-name-flash {
+    0%, 100% { box-shadow: none; }
+    25%, 75% { box-shadow: 0 0 14px 4px rgba(0,204,68,0.6); }
 }
 #pilot-name-input {
     background: transparent;
@@ -61,13 +116,20 @@
     border-bottom: 1px solid var(--border-bright);
     color: var(--green);
     font-family: var(--font-mono);
-    font-size: 16px;
+    font-size: 20px;
     letter-spacing: 3px;
     text-transform: uppercase;
     text-shadow: 0 0 6px var(--green);
     text-align: center;
-    width: 240px;
-    padding: 4px 2px;
+    width: 100%;
+    padding: 6px 2px;
+}
+#pilot-name-input::placeholder {
+    color: var(--text-dim);
+    text-shadow: none;
+    letter-spacing: 2px;
+    font-size: 14px;
+    opacity: 0.7;
 }
 #pilot-name-input:focus {
     outline: none;
@@ -75,53 +137,78 @@
 }
 .pilot-name-input-wrap .cursor {
     color: var(--green);
-    font-size: 16px;
+    font-size: 20px;
     text-shadow: 0 0 6px var(--green);
 }
 
-/* ── PILOT STATS PANEL ── */
+/* ── PILOT STATS PANEL (right panel) ── */
 .pilot-stats {
-    width: 280px;
+    width: 300px;
     flex: unset;
-    margin-top: 6px;
 }
 .pilot-stats .stat-row {
     display: flex;
     justify-content: space-between;
     align-items: baseline;
-    padding: 5px 0;
+    padding: 8px 0;
     border-bottom: 1px solid var(--border);
-    font-size: 11px;
+    font-size: 15px;
     letter-spacing: 1px;
 }
 .pilot-stats .stat-row:last-child { border-bottom: none; }
 .pilot-stats .stat-label { color: var(--text-dim); letter-spacing: 2px; }
 .pilot-stats .stat-value { color: var(--green); text-shadow: 0 0 6px var(--green); font-weight: bold; }
 
-/* ── PILOT INDEX INDICATOR ── */
-#pilot-index-indicator {
-    font-family: var(--font-mono);
-    font-size: 9px;
-    letter-spacing: 2px;
-    color: var(--text-dim);
-    margin-top: 4px;
-}
-
-/* ── PILOT CYCLE ARROWS ── */
-.pilot-arrows {
-    display: flex;
-    gap: 20px;
-    margin-top: 6px;
-}
-#pilot-arrows .ship-arrow-btn:disabled {
-    opacity: 0.25;
-    cursor: default;
-    pointer-events: none;
-}
-
 /* ── ACTIONS ── */
 .pilot-actions {
     display: flex;
     gap: 10px;
     margin-top: 10px;
+}
+
+.pilot-delete-btn {
+    color: var(--red);
+    border-color: var(--red);
+}
+.pilot-delete-btn::before {
+    color: var(--red);
+}
+.pilot-delete-btn:hover {
+    background: #1a0505;
+    border-color: var(--red);
+    color: var(--red);
+    text-shadow: 0 0 8px var(--red);
+    box-shadow: 0 0 12px rgba(204,34,0,0.25);
+}
+.pilot-delete-btn:hover::before {
+    color: var(--red);
+}
+
+/* ── DELETE CONFIRMATION ── */
+.pilot-delete-confirm {
+    position: fixed;
+    inset: 0;
+    z-index: 1001;
+    background: rgba(0,0,0,0.75);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.pilot-delete-confirm-box {
+    width: 420px;
+    flex: unset;
+    border-color: var(--red);
+}
+.pilot-delete-confirm-text {
+    font-family: var(--font-mono);
+    font-size: 14px;
+    line-height: 1.6;
+    color: var(--text);
+    padding: 6px 0 16px;
+    text-align: center;
+}
+.pilot-delete-confirm-actions {
+    display: flex;
+    justify-content: center;
+    gap: 12px;
 }

--- a/webGL/js/main.js
+++ b/webGL/js/main.js
@@ -121,12 +121,6 @@ function bindEventListeners() {
 	if (arrowLeft)  arrowLeft.onclick  = () => sceneManager.onKeyDown(37, 1000);
 	if (arrowRight) arrowRight.onclick = () => sceneManager.onKeyDown(39, 1000);
 
-	// pilot cycle arrows
-	const pilotArrowLeft  = document.getElementById('pilotArrowLeft');
-	const pilotArrowRight = document.getElementById('pilotArrowRight');
-	if (pilotArrowLeft)  pilotArrowLeft.onclick  = () => { PilotStore.cyclePrev(); PilotScreen.renderActivePilot(); };
-	if (pilotArrowRight) pilotArrowRight.onclick = () => { PilotStore.cycleNext(); PilotScreen.renderActivePilot(); };
-
 	resizeCanvas();
 }
 
@@ -266,8 +260,7 @@ function onSubMenuItemClick(event) {
         document.getElementById("selectBtn").disabled = false;
 		handler.connectToServer();
 	} else if(subMenuItem === "pilotnew") {
-		PilotStore.createPilot();
-		PilotScreen.renderActivePilot();
+		PilotScreen.createNewPilot();
 	} else if(subMenuItem === "leaveserver") {
 		// clear canvas
 		const canvas = document.getElementById('canvas');

--- a/webGL/js/pilot/PilotScreen.js
+++ b/webGL/js/pilot/PilotScreen.js
@@ -1,5 +1,6 @@
 import PilotStore from "./PilotStore.js";
 import portraits from "./portraits.js";
+import { showToast } from "../HUD/hud.js";
 
 let built = false;
 
@@ -30,31 +31,41 @@ export function buildScreen() {
                 <button class="ship-arrow-btn pilot-portrait-arrow" id="pilotPortraitNext">&#9654;</button>
             </div>
 
-            <div class="pilot-name-field">
-                <span class="pilot-name-label">PILOT NAME</span>
-                <span class="pilot-name-input-wrap">
-                    <input id="pilot-name-input" maxlength="20" autocomplete="off" spellcheck="false" />
-                    <span class="cursor">_</span>
-                </span>
-            </div>
+            <div class="pilot-panels">
+                <div class="pilot-list-panel panel">
+                    <div class="panel-title">PILOTS</div>
+                    <div class="pilot-list" id="pilot-list"></div>
+                    <div class="pilot-name-field">
+                        <span class="pilot-name-input-wrap" id="pilot-name-input-wrap">
+                            <input id="pilot-name-input" maxlength="20" autocomplete="off" spellcheck="false" placeholder="ENTER PILOT NAME" />
+                            <span class="cursor">_</span>
+                        </span>
+                    </div>
+                </div>
 
-            <div class="panel pilot-stats">
-                <div class="panel-title">IMPERIAL DATABASE</div>
-                <div class="stat-row"><span class="stat-label">RANK</span><span class="stat-value" id="pilot-stat-rank"></span></div>
-                <div class="stat-row"><span class="stat-label">SCORE</span><span class="stat-value" id="pilot-stat-score"></span></div>
-                <div class="stat-row"><span class="stat-label">MISSIONS FLOWN</span><span class="stat-value" id="pilot-stat-missions"></span></div>
-            </div>
-
-            <div id="pilot-index-indicator"></div>
-
-            <div id="pilot-arrows" class="pilot-arrows">
-                <button class="ship-arrow-btn" id="pilotArrowLeft">&#9664;</button>
-                <button class="ship-arrow-btn" id="pilotArrowRight">&#9654;</button>
+                <div class="panel pilot-stats">
+                    <div class="panel-title">IMPERIAL DATABASE</div>
+                    <div class="stat-row"><span class="stat-label">RANK</span><span class="stat-value" id="pilot-stat-rank"></span></div>
+                    <div class="stat-row"><span class="stat-label">SCORE</span><span class="stat-value" id="pilot-stat-score"></span></div>
+                    <div class="stat-row"><span class="stat-label">MISSIONS FLOWN</span><span class="stat-value" id="pilot-stat-missions"></span></div>
+                </div>
             </div>
 
             <div class="pilot-actions">
                 <button id="pilotNewBtn" class="sub-menu-item" name="pilotnew">NEW PILOT</button>
+                <button id="pilotDeleteBtn" class="sub-menu-item pilot-delete-btn" name="pilotdelete">DELETE PILOT</button>
                 <button id="pilotBackBtn" class="nav-btn launch sub-menu-item" name="back">CONTINUE ►</button>
+            </div>
+        </div>
+
+        <div id="pilot-delete-confirm" class="pilot-delete-confirm" style="display:none;">
+            <div class="pilot-delete-confirm-box panel">
+                <div class="panel-title">CONFIRM DELETION</div>
+                <div class="pilot-delete-confirm-text" id="pilot-delete-confirm-text"></div>
+                <div class="pilot-delete-confirm-actions">
+                    <button id="pilotDeleteCancelBtn" class="sub-menu-item" name="pilotdeletecancel">CANCEL</button>
+                    <button id="pilotDeleteConfirmBtn" class="sub-menu-item pilot-delete-btn" name="pilotdeleteconfirm">CONFIRM DELETE</button>
+                </div>
             </div>
         </div>
     `;
@@ -63,10 +74,35 @@ export function buildScreen() {
     nameInput.addEventListener('input', () => {
         const active = PilotStore.getActivePilot();
         PilotStore.renamePilot(active.id, nameInput.value);
+        renderPilotList(); // keep the list label in sync as the player types
     });
 
     document.getElementById('pilotPortraitPrev').addEventListener('click', () => cyclePortrait(-1));
     document.getElementById('pilotPortraitNext').addEventListener('click', () => cyclePortrait(1));
+
+    document.getElementById('pilotDeleteBtn').addEventListener('click', showDeleteConfirm);
+    document.getElementById('pilotDeleteCancelBtn').addEventListener('click', hideDeleteConfirm);
+    document.getElementById('pilotDeleteConfirmBtn').addEventListener('click', confirmDeleteActivePilot);
+}
+
+function showDeleteConfirm() {
+    const pilot = PilotStore.getActivePilot();
+    const label = pilot.name || 'THIS UNNAMED PILOT';
+    document.getElementById('pilot-delete-confirm-text').textContent =
+        `DELETE ${label}? THIS CANNOT BE UNDONE.`;
+    document.getElementById('pilot-delete-confirm').style.display = 'flex';
+}
+
+function hideDeleteConfirm() {
+    document.getElementById('pilot-delete-confirm').style.display = 'none';
+}
+
+function confirmDeleteActivePilot() {
+    const pilot = PilotStore.getActivePilot();
+    PilotStore.deletePilot(pilot.id);
+    hideDeleteConfirm();
+    renderActivePilot();
+    showToast(`PILOT ${pilot.name || 'RECORD'} DELETED`, 4000);
 }
 
 function cyclePortrait(step) {
@@ -94,10 +130,46 @@ function renderPortrait(pilot) {
     }
 }
 
+function selectPilot(id) {
+    PilotStore.setActivePilotId(id);
+    renderActivePilot();
+}
+
+function renderPilotList() {
+    const pilots = PilotStore.getPilots();
+    const activePilot = PilotStore.getActivePilot();
+    const listEl = document.getElementById('pilot-list');
+
+    listEl.innerHTML = pilots.map(p => `
+        <div class="pilot-list-item${p.id === activePilot.id ? ' active' : ''}" data-pilot-id="${p.id}">
+            ${p.name ? escapeHtml(p.name) : '<span class="pilot-list-item-unnamed">UNNAMED</span>'}
+        </div>
+    `).join('');
+
+    listEl.querySelectorAll('.pilot-list-item').forEach(el => {
+        el.addEventListener('click', () => selectPilot(el.getAttribute('data-pilot-id')));
+    });
+}
+
+function escapeHtml(str) {
+    const div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+}
+
+export function createNewPilot() {
+    PilotStore.createPilot();
+    renderActivePilot();
+    showToast('NEW PILOT CREATED — ENTER A NAME BELOW', 4000);
+
+    const wrap = document.getElementById('pilot-name-input-wrap');
+    wrap.classList.remove('flash');
+    void wrap.offsetWidth; // restart the animation if triggered again in quick succession
+    wrap.classList.add('flash');
+}
+
 export function renderActivePilot() {
     const pilot = PilotStore.getActivePilot();
-    const pilots = PilotStore.getPilots();
-    const index = pilots.findIndex(p => p.id === pilot.id);
 
     const nameInput = document.getElementById('pilot-name-input');
     if (document.activeElement !== nameInput) {
@@ -107,14 +179,9 @@ export function renderActivePilot() {
     document.getElementById('pilot-stat-rank').textContent = pilot.rank;
     document.getElementById('pilot-stat-score').textContent = pilot.score;
     document.getElementById('pilot-stat-missions').textContent = pilot.missionsFlown;
-    document.getElementById('pilot-index-indicator').textContent = `PILOT ${index + 1} / ${pilots.length}`;
-
-    const leftArrow = document.getElementById('pilotArrowLeft');
-    const rightArrow = document.getElementById('pilotArrowRight');
-    leftArrow.disabled = pilots.length <= 1;
-    rightArrow.disabled = pilots.length <= 1;
 
     renderPortrait(pilot);
+    renderPilotList();
 
     if (!pilot.name) {
         nameInput.focus();
@@ -122,4 +189,4 @@ export function renderActivePilot() {
     }
 }
 
-export default { buildScreen, renderActivePilot };
+export default { buildScreen, renderActivePilot, createNewPilot };

--- a/webGL/js/pilot/PilotStore.js
+++ b/webGL/js/pilot/PilotStore.js
@@ -108,24 +108,6 @@ function setPilotPortrait(id, portraitId) {
     writePilots(pilots);
 }
 
-function cycleBy(step) {
-    const pilots = getPilots();
-    if (pilots.length <= 1) return getActivePilot();
-    const activeId = LocalStorage.getItem(ACTIVE_PILOT_ID_KEY);
-    const currentIndex = Math.max(0, pilots.findIndex(p => p.id === activeId));
-    const nextIndex = (currentIndex + step + pilots.length) % pilots.length;
-    setActivePilotId(pilots[nextIndex].id);
-    return withRank(pilots[nextIndex]);
-}
-
-function cycleNext() {
-    return cycleBy(1);
-}
-
-function cyclePrev() {
-    return cycleBy(-1);
-}
-
 function awardKillScore() {
     const pilots = getPilots();
     const activeId = LocalStorage.getItem(ACTIVE_PILOT_ID_KEY);
@@ -144,6 +126,21 @@ function awardMissionCompleteBonus() {
     return SCORE_VALUES.MISSION_COMPLETE_BONUS;
 }
 
+function deletePilot(id) {
+    const pilots = getPilots().filter(p => p.id !== id);
+    writePilots(pilots);
+
+    if (LocalStorage.getItem(ACTIVE_PILOT_ID_KEY) !== id) return;
+
+    if (pilots.length > 0) {
+        setActivePilotId(pilots[pilots.length - 1].id);
+    } else {
+        // leave PILOTS as an empty array — the next getPilots() call
+        // auto-reseeds a fresh default pilot and makes it active
+        LocalStorage.removeItem(ACTIVE_PILOT_ID_KEY);
+    }
+}
+
 function incrementMissionsFlown() {
     const pilots = getPilots();
     const activeId = LocalStorage.getItem(ACTIVE_PILOT_ID_KEY);
@@ -160,10 +157,9 @@ export default {
     getActivePilot,
     setActivePilotId,
     createPilot,
+    deletePilot,
     renamePilot,
     setPilotPortrait,
-    cycleNext,
-    cyclePrev,
     awardKillScore,
     awardMissionCompleteBonus,
     incrementMissionsFlown,


### PR DESCRIPTION
## Summary

- Increase font sizes across the pilot screen (name field, stats panel, portrait arrows) for readability.
- Make "NEW PILOT" feedback obvious instead of just a silent counter tick — shows a toast ("NEW PILOT CREATED — ENTER A NAME BELOW") and flashes a highlight around the now-empty, auto-focused name field.
- Redesign the layout to match the original TIE Fighter's pilot terminal (per reference screenshot): a scrollable pilot list on the left (click to select any saved pilot) alongside the IMPERIAL DATABASE stats panel on the right, replacing the old prev/next cycle-arrow mechanism.
- Add delete-pilot with an in-universe confirmation overlay (not a browser `confirm()` popup) — "DELETE `<name>`? THIS CANNOT BE UNDONE." with CANCEL/CONFIRM DELETE. Deleting the only remaining pilot relies on `PilotStore`'s existing auto-reseed-on-empty logic to create a fresh default rather than special-casing it.
- Fixed a bug hit while building this: buttons with the `sub-menu-item` class but no `name` attribute crashed `main.js`'s generic click dispatcher (`Cannot read properties of null (reading 'search')`). Removed the now-unused `PilotStore.cycleNext`/`cyclePrev`.

## Test plan
- [x] Updated `e2e/pilot.spec.js` for the new list-based selection (10 tests total, 3 new: list select, delete+reseed, delete-keeps-others) — all pass.
- [x] Existing `e2e/smoke.spec.js` still passes.
- [x] Visually verified the new layout and delete confirmation flow in live browser runs against the reference screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)