### PR TITLE
Menu reorder, abort-mission flow, and pilot-screen music fix

### DIFF
--- a/webGL/css/menu.css
+++ b/webGL/css/menu.css
@@ -321,3 +321,49 @@
     background: rgba(0,5,2,0.85);
     visibility: hidden;
 }
+
+/* ── ABORT MISSION CONFIRMATION ── */
+.abort-mission-confirm {
+    position: fixed;
+    inset: 0;
+    z-index: 2600;
+    background: rgba(0,0,0,0.75);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.abort-mission-confirm-box {
+    width: 420px;
+    flex: unset;
+    border-color: var(--red);
+}
+.abort-mission-confirm-text {
+    font-family: var(--font-mono);
+    font-size: 14px;
+    line-height: 1.6;
+    color: var(--text);
+    padding: 6px 0 16px;
+    text-align: center;
+}
+.abort-mission-confirm-actions {
+    display: flex;
+    justify-content: center;
+    gap: 12px;
+}
+.abort-mission-confirm-btn {
+    color: var(--red);
+    border-color: var(--red);
+}
+.abort-mission-confirm-btn::before {
+    color: var(--red);
+}
+.abort-mission-confirm-btn:hover {
+    background: #1a0505;
+    border-color: var(--red);
+    color: var(--red);
+    text-shadow: 0 0 8px var(--red);
+    box-shadow: 0 0 12px rgba(204,34,0,0.25);
+}
+.abort-mission-confirm-btn:hover::before {
+    color: var(--red);
+}

--- a/webGL/index.html
+++ b/webGL/index.html
@@ -201,8 +201,8 @@
 		<div id="menu">
 			<div class="menu">
 				<div class="menu-title">IMPERIAL COMBAT SIMULATOR</div>
-				<div class="menu-item" name="shipselect">MULTI-PLAYER</div>
 				<div class="menu-item" name="campaign">CAMPAIGN</div>
+				<div class="menu-item" name="shipselect">MULTI-PLAYER</div>
 				<div class="menu-item" name="pilot">PILOT</div>
 				<div class="menu-item" name="settings">SETTINGS</div>
 			</div>
@@ -211,7 +211,18 @@
 			<div class="menu">
 				<div class="menu-title">PAUSED</div>
 				<div class="pause-menu-item" id="pauseResumeBtn">RESUME</div>
-				<div class="pause-menu-item" id="pauseQuitBtn">RETURN TO MAIN MENU</div>
+				<div class="pause-menu-item" id="pauseSettingsBtn">SETTINGS</div>
+				<div class="pause-menu-item" id="pauseQuitBtn">ABORT MISSION</div>
+			</div>
+			<div id="abort-mission-confirm" class="abort-mission-confirm" style="display:none;">
+				<div class="abort-mission-confirm-box panel">
+					<div class="panel-title">CONFIRM ABORT</div>
+					<div class="abort-mission-confirm-text">ABORT MISSION AND RETURN TO MAIN MENU? PROGRESS ON THIS MISSION WILL BE LOST.</div>
+					<div class="abort-mission-confirm-actions">
+						<button id="abortMissionCancelBtn" class="sub-menu-item" name="abortcancel">CANCEL</button>
+						<button id="abortMissionConfirmBtn" class="sub-menu-item abort-mission-confirm-btn" name="abortconfirm">CONFIRM ABORT</button>
+					</div>
+				</div>
 			</div>
 		</div>
 		<div id="campaign-menu">

--- a/webGL/js/main.js
+++ b/webGL/js/main.js
@@ -27,11 +27,12 @@ const canvas2 = document.getElementById('targetComputer');
 views.push(new View(canvas));
 views.push(new View(canvas2));
 
-let showMenu = false;
-let campaignMenu = false;
 let activeCampaignConfig = null;
 let inMission = false;
 let paused = false;
+// tracks whether the settings screen was opened from the pause menu, so its
+// back button returns there instead of running the normal main-menu "back" flow
+let settingsOpenedFromPause = false;
 
 let sceneManager = SceneManager(views, "menu");
 bindEventListeners();
@@ -58,7 +59,10 @@ bindEventListeners(); // re-run so the freshly-injected pilot-screen buttons get
 // pause menu buttons are static markup, wired once — deliberately not using the
 // .menu-item class (which the generic onMenuItemClick dispatch would misroute)
 document.getElementById('pauseResumeBtn').addEventListener('click', resumeFromPause);
-document.getElementById('pauseQuitBtn').addEventListener('click', quitToMainMenuFromPause);
+document.getElementById('pauseSettingsBtn').addEventListener('click', openSettingsFromPause);
+document.getElementById('pauseQuitBtn').addEventListener('click', showAbortMissionConfirm);
+document.getElementById('abortMissionCancelBtn').addEventListener('click', hideAbortMissionConfirm);
+document.getElementById('abortMissionConfirmBtn').addEventListener('click', abortMissionFromPause);
 
 EventBus.subscribe(events.MISSION_COMPLETE, () => {
 	PilotStore.incrementMissionsFlown();
@@ -216,8 +220,6 @@ function onMenuItemClick(event) {
 		const canvas = document.getElementById('canvas');
 		canvas.innerHTML = "";
 
-		campaignMenu = false;
-
 		// show subMenu
 		const subMenu = document.getElementById("sub-menu");
 		subMenu.style.visibility = "visible";
@@ -254,7 +256,6 @@ function onMenuItemClick(event) {
 		// show campaign-menu
 		const subMenu = document.getElementById("campaign-menu");
 		subMenu.style.visibility = "visible";
-		campaignMenu = true;
 		CampaignMenu.buildMenu();
 	}
 	// load scene
@@ -314,6 +315,9 @@ function onSubMenuItemClick(event) {
 		bindEventListeners();
         handler.startGame();
         inMission = true;
+        // clear any stale campaign config from a previous mission so an in-mission
+        // pause/abort here correctly takes the multiplayer path, not the debrief one
+        activeCampaignConfig = null;
 	} else if(subMenuItem === "connect") {
 		// const element3 = document.getElementById("start");
 		// element3.style.disabled = false;
@@ -358,6 +362,15 @@ function onSubMenuItemClick(event) {
 		sceneManager = SceneManager(views, "shipselect");
 		bindEventListeners();
 	} else if(subMenuItem === "back") {
+		// settings opened from the in-mission pause menu should return there,
+		// not run the main-menu "back" flow below (which would drop the mission)
+		if (settingsOpenedFromPause) {
+			settingsOpenedFromPause = false;
+			document.getElementById("settings-screen").style.visibility = "hidden";
+			document.getElementById("pause-menu").style.visibility = "visible";
+			return;
+		}
+
 		const canvas = document.getElementById('canvas');
 		canvas.innerHTML = "";
 
@@ -453,10 +466,40 @@ function resumeFromPause() {
 	document.getElementById('pause-menu').style.visibility = 'hidden';
 }
 
-function quitToMainMenuFromPause() {
+function openSettingsFromPause() {
+	// leave inMission/paused untouched — the game stays frozen behind the
+	// settings screen, same as it was behind the pause menu
+	settingsOpenedFromPause = true;
+	document.getElementById('pause-menu').style.visibility = 'hidden';
+	document.getElementById('settings-screen').style.visibility = 'visible';
+	SettingsScreen.buildScreen();
+	SettingsScreen.renderSettings();
+	bindEventListeners();
+}
+
+function showAbortMissionConfirm() {
+	document.getElementById('abort-mission-confirm').style.display = 'flex';
+}
+
+function hideAbortMissionConfirm() {
+	document.getElementById('abort-mission-confirm').style.display = 'none';
+}
+
+function abortMissionFromPause() {
+	hideAbortMissionConfirm();
+	document.getElementById('pause-menu').style.visibility = 'hidden';
+
+	// the debrief screen is campaign-only (it reads activeCampaignConfig directly) —
+	// a multiplayer match has no campaign config, so it still drops straight to the
+	// main menu instead
+	if (activeCampaignConfig) {
+		PilotStore.incrementMissionsFlown();
+		showDebrief('failure', 'Mission aborted by pilot.', getMissionScore());
+		return;
+	}
+
 	inMission = false;
 	paused = false;
-	document.getElementById('pause-menu').style.visibility = 'hidden';
 	document.getElementById('heads-up-display').style.visibility = 'hidden';
 
 	const canvas = document.getElementById('canvas');
@@ -466,47 +509,15 @@ function quitToMainMenuFromPause() {
 	bindEventListeners();
 }
 
-function isMainMenuAreaVisible() {
-	return document.getElementById('menu').style.visibility === 'visible'
-		|| document.getElementById('pilot-screen').style.visibility === 'visible'
-		|| document.getElementById('settings-screen').style.visibility === 'visible';
-}
-
 function onKeyDown(event, duration) {
 	if(event.keyCode === 27){
-		// during actual gameplay (campaign mission or multiplayer match), Esc
-		// opens a dedicated pause menu instead of the Battle/Campaign-select or
-		// ship-select screens — those don't make sense to land on mid-flight
+		// Esc only does something during actual gameplay (campaign mission or
+		// multiplayer match), opening a dedicated pause menu. On the ship-select or
+		// campaign-select screens it used to hide the whole panel, revealing a stale
+		// scene behind it with no way back, so it's a no-op there now.
 		if(inMission){
 			togglePauseMenu();
-			return;
 		}
-
-		// the sub-menu/campaign-menu toggle below is only meaningful while actually
-		// inside the ship-select or campaign-select flow — on the main menu, pilot
-		// screen, or settings screen there's nothing for Esc to show, so bail out
-		// rather than have stale showMenu/campaignMenu state pop up an unrelated menu
-		if(isMainMenuAreaVisible()) return;
-
-		const element3 = document.getElementById("sub-menu");
-		// show menu
-		if(showMenu && !campaignMenu){
-			element3.style.visibility = "visible";
-			showMenu = false;
-		} else if(!showMenu && !campaignMenu) {
-			element3.style.visibility = "hidden";
-			showMenu = true;
-		}
-		const element = document.getElementById("campaign-menu");
-		// show campaign menu
-		if(showMenu && campaignMenu){
-			element.style.visibility = "visible";
-			showMenu = false;
-		} else if(!showMenu && campaignMenu) {
-			element.style.visibility = "hidden";
-			showMenu = true;
-		}
-
 	} else {
 		sceneManager.onKeyDown(event.keyCode, duration);
 	}

--- a/webGL/js/utils/Audio.js
+++ b/webGL/js/utils/Audio.js
@@ -158,12 +158,25 @@ let audioReady = false;
 
 // browsers start every AudioContext suspended until a user gesture unlocks it —
 // the menu music plays before the player has clicked anything, so without this
-// it gets silently scheduled-but-muted and never catches up on its own
+// it gets silently scheduled-but-muted and never catches up on its own. Resuming
+// the context doesn't retroactively make an already-scheduled source audible
+// either, so any music that started while still suspended needs to be replayed
+// once we're actually unlocked, not just left to "catch up".
 function unlockAudioContext() {
     const ctx = THREE.AudioContext.getContext();
     if (ctx.state === 'suspended') {
-        ctx.resume();
+        ctx.resume().then(restartMusicStartedWhileSuspended);
     }
+}
+
+function restartMusicStartedWhileSuspended() {
+    Object.keys(AudioType).forEach(key => {
+        const entry = AudioType[key];
+        if (entry.type === "MUSIC" && entry.sound && entry.sound.isPlaying) {
+            entry.sound.stop();
+            entry.sound.play();
+        }
+    });
 }
 window.addEventListener('pointerdown', unlockAudioContext);
 window.addEventListener('keydown', unlockAudioContext);


### PR DESCRIPTION
## Summary
- Swapped main menu order so CAMPAIGN sits above MULTI-PLAYER
- Esc on the ship-select/campaign-select screens is now a no-op instead of hiding the whole panel and revealing a stale scene behind it
- Added a SETTINGS option to the in-mission pause menu (returns to pause menu, not main menu, on back)
- Renamed "RETURN TO MAIN MENU" to "ABORT MISSION" and added a confirmation dialog; confirming during a campaign mission now routes through the mission debrief screen instead of dropping straight to the main menu (multiplayer aborts are unaffected)
- Fixed pilot-screen music sometimes never playing: menu music that started before the AudioContext's first user-gesture unlock was scheduled while suspended and never became audible even after the context resumed; it's now restarted once actually unlocked

## Test plan
- [x] Verified in-browser: menu order, Esc no-op on ship-select/campaign screens, pause menu Settings entry (returns to pause, not main menu), Abort Mission confirmation + debrief routing
- [x] Reproduced the audio race live (confirmed `play()` firing while `ctx.state === 'suspended'`) and confirmed the restart-on-unlock fix runs without errors
- [ ] Manual listen-test on your end to confirm pilot-screen music is now reliably audible

🤖 Generated with [Claude Code](https://claude.com/claude-code)