### PR TITLE
Add game status, CI, and deploy badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Tie Fighter
 
+[![Game Status](https://img.shields.io/website?url=https%3A%2F%2Ftie-fighter.mattsanders.org&up_message=online&down_message=offline&label=game%20status)](https://tie-fighter.mattsanders.org)
+[![CI](https://github.com/sandman45/TieFighter/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/sandman45/TieFighter/actions/workflows/ci.yml)
+[![Deploy](https://github.com/sandman45/TieFighter/actions/workflows/deploy.yml/badge.svg?branch=master)](https://github.com/sandman45/TieFighter/actions/workflows/deploy.yml)
+
 A Star Wars TIE Fighter browser game: a Three.js (WebGL) client with
 single-player campaign missions and a Socket.IO-based multiplayer mode,
 backed by a small Node/Express real-time server.


### PR DESCRIPTION
## Summary
- Added a **Game Status** badge that pings the live site (tie-fighter.mattsanders.org) directly via shields.io and shows online/offline
- Added a **CI** badge linking to the `ci.yml` workflow (build, server integration tests, Playwright e2e)
- Added a **Deploy** badge linking to the `deploy.yml` workflow (EC2 deploy on push to master)

## Test plan
- [x] Verified all three badge image URLs render (200, image/svg+xml) before adding
- [x] Verified the live site responds (200) for the status badge target

🤖 Generated with [Claude Code](https://claude.com/claude-code)