### PR TITLE
Add per-ship laser/shield recharge rates

### DIFF
--- a/webGL/js/controls/FlyControls.js
+++ b/webGL/js/controls/FlyControls.js
@@ -30,7 +30,7 @@ export default class FlyControls {
         this.updateThrottleReadout();
         this.collisionManager = collisionManager;
         this.dockingManager = null;
-        this.weaponsEnergy = WeaponsEnergy();
+        this.weaponsEnergy = WeaponsEnergy({ rechargeRate: object.laserRechargeRate });
         this._lastEnergyTick = null;
         eventBus.post(eventBusEvents.WEAPON_ENERGY_CHANGED, {
             energy: this.weaponsEnergy.getEnergy(),

--- a/webGL/js/controls/PlayerControls.js
+++ b/webGL/js/controls/PlayerControls.js
@@ -22,7 +22,7 @@ export default (mesh, laser, camera, config, collisionManager, audio) => {
     let backward = false;
     let rotating = false;
     let lastEnergyTick = null;
-    const weaponsEnergy = WeaponsEnergy();
+    const weaponsEnergy = WeaponsEnergy({ rechargeRate: mesh.laserRechargeRate });
     eventBus.post(eventBusEvents.WEAPON_ENERGY_CHANGED, {
         energy: weaponsEnergy.getEnergy(),
         maxEnergy: weaponsEnergy.getMaxEnergy(),
@@ -115,6 +115,17 @@ export default (mesh, laser, camera, config, collisionManager, audio) => {
     }
 
     function update(time) {
+        // SceneManager calls update() with total elapsed time, not a per-frame
+        // delta, so derive the delta here for the recharge-rate math
+        const energyDt = (lastEnergyTick === null) ? 0 : Math.max(0, time - lastEnergyTick);
+        lastEnergyTick = time;
+        if (weaponsEnergy.update(energyDt)) {
+            eventBus.post(eventBusEvents.WEAPON_ENERGY_CHANGED, {
+                energy: weaponsEnergy.getEnergy(),
+                maxEnergy: weaponsEnergy.getMaxEnergy(),
+            });
+        }
+
         const matrix = new THREE.Matrix4();
         matrix.extractRotation( mesh.matrix );
         let directionVector;

--- a/webGL/js/utils/ModelLoader.js
+++ b/webGL/js/utils/ModelLoader.js
@@ -2,6 +2,9 @@ import * as THREE from 'https://threejsfundamentals.org/threejs/resources/threej
 import {GLTFLoader} from 'https://threejsfundamentals.org/threejs/resources/threejs/r119/examples/jsm/loaders/GLTFLoader.js';
 import createFighterFSM from "../ai/FighterFSM.js";
 import createShuttleFSM from "../ai/ShuttleFSM.js";
+import eventBus from "../eventBus/EventBus.js";
+import events from "../eventBus/events.js";
+import { resolveLaserRechargeRate, resolveShieldRechargeRate } from "./shipRechargeConfig.js";
 
 export const Model = {
     TIE_FIGHTER: "models/tie-fighter/tie.glb",
@@ -34,6 +37,8 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
     group.shields = modelConfiguration.shields;
     group.maxHull = modelConfiguration.hull;
     group.maxShields = modelConfiguration.shields;
+    group.laserRechargeRate = resolveLaserRechargeRate(modelConfiguration);
+    group.shieldRechargeRate = resolveShieldRechargeRate(modelConfiguration);
     group.name = modelConfiguration.name;
     group.userId = modelConfiguration.userId ? modelConfiguration.userId : modelConfiguration.designation;
     group.designation = modelConfiguration.designation;
@@ -140,13 +145,39 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
     }
 
     function update(time) {
+        const delta = Math.max(0, time - lastTime);
         if(mixer && time && modelReady){
-            const delta = time - lastTime;
             mixer.update(delta);
         }
         lastTime = time;
         if(fsm) {
             fsm.update();
+        }
+        regenShields(delta);
+    }
+
+    // shields (not hull) trickle-recharge over time for ships that have any;
+    // reuses the PLAYER_DAMAGED/TARGET_DAMAGED shapes the HUD already listens
+    // to for damage, so no HUD changes are needed
+    function regenShields(delta) {
+        if(group.shieldRechargeRate <= 0 || group.hull <= 0 || group.shields >= group.maxShields) return;
+
+        group.shields = Math.min(group.maxShields, group.shields + group.shieldRechargeRate * delta);
+
+        const payload = {
+            shields: group.shields,
+            maxShields: group.maxShields,
+            hull: group.hull,
+            maxHull: group.maxHull,
+        };
+        if(modelConfiguration.playerName) {
+            eventBus.post(events.PLAYER_DAMAGED, payload);
+        } else {
+            eventBus.post(events.TARGET_DAMAGED, {
+                ...payload,
+                userId: group.userId,
+                designation: group.designation,
+            });
         }
     }
 

--- a/webGL/js/utils/shipRechargeConfig.js
+++ b/webGL/js/utils/shipRechargeConfig.js
@@ -1,0 +1,35 @@
+export const SHIP_RECHARGE_RATES = {
+    // Imperial — TIE Bomber is the slowest (heavy ordnance ship), TIE Fighter
+    // second-slowest (baseline, no shields but unremarkable tech), and the
+    // Interceptor/Advanced/Defender are all superior imperial craft with
+    // faster recharge than the plain Fighter.
+    TIE_BOMBER:      { laserRechargeRate: 18 },
+    TIE_FIGHTER:     { laserRechargeRate: 22 },
+    TIE_ADVANCED:    { laserRechargeRate: 23, shieldRechargeRate: 4 },
+    TIE_INTERCEPTOR: { laserRechargeRate: 25 },
+    TIE_DEFENDER:    { laserRechargeRate: 27, shieldRechargeRate: 5 },
+    // Rebel
+    A_WING:          { laserRechargeRate: 22, shieldRechargeRate: 5 },
+    X_WING:          { laserRechargeRate: 20, shieldRechargeRate: 4 },
+    Y_WING:          { laserRechargeRate: 15, shieldRechargeRate: 3 },
+    B_WING:          { laserRechargeRate: 17, shieldRechargeRate: 3 },
+    // Non-combat / capital — deliberately below every fighter's laser rate
+    SHUTTLE:         { laserRechargeRate: 12, shieldRechargeRate: 3 },
+    TRANSPORT:       { laserRechargeRate: 12, shieldRechargeRate: 3 },
+    ISD:             { laserRechargeRate: 10, shieldRechargeRate: 6 },
+};
+
+export const DEFAULT_LASER_RECHARGE_RATE = 20;
+export const DEFAULT_SHIELD_RECHARGE_RATE = 0;
+
+export function resolveLaserRechargeRate(modelConfiguration) {
+    if (modelConfiguration.laserRechargeRate !== undefined) return modelConfiguration.laserRechargeRate;
+    const rates = SHIP_RECHARGE_RATES[modelConfiguration.name];
+    return (rates && rates.laserRechargeRate !== undefined) ? rates.laserRechargeRate : DEFAULT_LASER_RECHARGE_RATE;
+}
+
+export function resolveShieldRechargeRate(modelConfiguration) {
+    if (modelConfiguration.shieldRechargeRate !== undefined) return modelConfiguration.shieldRechargeRate;
+    const rates = SHIP_RECHARGE_RATES[modelConfiguration.name];
+    return (rates && rates.shieldRechargeRate !== undefined) ? rates.shieldRechargeRate : DEFAULT_SHIELD_RECHARGE_RATE;
+}


### PR DESCRIPTION
## Summary
- Add a per-ship-type recharge table (`webGL/js/utils/shipRechargeConfig.js`) so laser cannons and shields no longer share one global recharge rate — unshielded/agile fighters recharge lasers faster, heavier and capital ships slower.
- Add passive shield regen for any ship with shields (hull damage still never heals), wired into `ModelLoader.js`'s existing per-frame update and reusing the existing `PLAYER_DAMAGED`/`TARGET_DAMAGED` HUD events — no HUD changes needed.
- Fix `PlayerControls.js`, which previously never actually ticked its laser recharge timer.

## Test plan
- [x] `cd server && node --test test/integration.test.js` — 7/7 pass
- [x] Manual playtest: TIE Fighter laser bar drains on fire and refills at its new rate; shield bar stays empty (no shields); targeted Y-Wing shows full shields/hull; no console errors during play
- [x] Playtest a shielded ship (X-Wing/Y-Wing/TIE Advanced etc.) taking shield damage and confirm the shield bar regenerates while hull damage stays permanent

🤖 Generated with [Claude Code](https://claude.com/claude-code)