### PR TITLE
Wire up X-wing S-foil animation, disable debug 'X' key

### DIFF
--- a/webGL/js/SceneManager.js
+++ b/webGL/js/SceneManager.js
@@ -254,13 +254,6 @@ export default (views, screen) => {
         if(mp){
             controls = mp.getControls();
         }
-        if(keyCode === 88){
-            sceneSubjects.forEach(sub=>{
-                if(sub.playAnimations){
-                    sub.playAnimations();
-                }
-            });
-        }
         if(controls){
             controls.onKeyDown(keyCode, duration);
         }

--- a/webGL/js/ai/InterceptorFSM.js
+++ b/webGL/js/ai/InterceptorFSM.js
@@ -35,7 +35,7 @@ const latestRunIdByDesignation = new Map();
 // same attack/egress shape as FighterFSM's ISD attack runs, just without any
 // of FighterFSM's ISD-hull-shaped avoidance/waypoint machinery, since neither
 // the shuttle nor the player have anything like the ISD's hull to route around.
-export default ({ scene, modelGroup, modelConfiguration, collisionManager, audio, laser }) => {
+export default ({ scene, modelGroup, modelConfiguration, collisionManager, audio, laser, wingsUp, wingsDown }) => {
     const runId = (latestRunIdByDesignation.get(modelGroup.designation) || 0) + 1;
     latestRunIdByDesignation.set(modelGroup.designation, runId);
     const cm = collisionManager;
@@ -305,6 +305,17 @@ export default ({ scene, modelGroup, modelConfiguration, collisionManager, audio
         withdraw: {
             enter: () => {
                 console.log(`${modelGroup.designation} X-WING entering WITHDRAW — returning to hyperspace point`);
+
+                // gated to one ship so the flight's three fighters don't each
+                // pop their own duplicate toast — same convention as the
+                // arrival toast/FighterFSM's logEvent
+                if(modelGroup.designation === 'RED_LEADER') {
+                    showToast('REBEL X-WINGS RETREATING — BREAKING OFF ATTACK');
+                }
+
+                // S-foils closed for the cruise back to the hyperspace point
+                wingsUp();
+
                 const home = modelConfiguration.position;
                 const target = new THREE.Vector3(home.x, home.y, home.z);
                 const initialVelocity = new THREE.Vector3()
@@ -356,6 +367,10 @@ export default ({ scene, modelGroup, modelConfiguration, collisionManager, audio
         // targeting scope at the exact moment it starts moving
         modelGroup.visible = true;
         modelGroup.arrived = true;
+
+        // S-foils into attack position — same play-half-of-"Take 01" trick
+        // ModelLoader wires up for the shuttle's wings
+        wingsDown();
 
         // gated to one ship so the flight's three fighters don't each pop
         // their own duplicate toast — same convention as FighterFSM's logEvent

--- a/webGL/js/utils/ModelLoader.js
+++ b/webGL/js/utils/ModelLoader.js
@@ -71,7 +71,7 @@ export default (scene, modelConfiguration, model, modelGltf, collisionManager, a
         if(modelConfiguration.name === 'SHUTTLE') {
             fsm = createShuttleFSM({ scene, modelGroup: group, modelConfiguration, collisionManager: cm, audio, laser, wingsUp, wingsDown });
         } else if(modelConfiguration.name === 'X_WING') {
-            fsm = createInterceptorFSM({ scene, modelGroup: group, modelConfiguration, collisionManager: cm, audio, laser });
+            fsm = createInterceptorFSM({ scene, modelGroup: group, modelConfiguration, collisionManager: cm, audio, laser, wingsUp, wingsDown });
         } else {
             fsm = createFighterFSM({ scene, modelGroup: group, modelConfiguration, collisionManager: cm, audio, laser });
         }


### PR DESCRIPTION
## Summary
- The X-wing GLB ships with its own "Take 01" animation clip on the S-foil wing nodes, using the same play-half-of-the-clip convention `ModelLoader.js` already uses for the shuttle's wings — reused as-is rather than adding new machinery.
- `InterceptorFSM` now opens the S-foils the instant an X-wing hyperspaces in, and closes them when it withdraws.
- Removed the leftover debug 'X' key binding (`SceneManager.js`) that toggled animation playback on every ship in the scene — harmless before, but it would now interfere with this choreographed wing timing.

## Test plan
- [x] Verified live in-browser: X-wing's target-computer silhouette shows the full "X" attack-position spread right when it arrives
- [x] Confirmed via console logs that `wingsDown`/`wingsUp` fire at the right FSM transitions with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)